### PR TITLE
Add debug to help diagnosing non-validation errors.

### DIFF
--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -6,7 +6,7 @@ app = typer.Typer()
 
 
 @app.command()
-def validate(name: str):
+def validate(name: str, debug: bool = False):
     """Validate manifest for a distribution name or manifest filepath."""
 
     valid = False
@@ -18,6 +18,8 @@ def validate(name: str):
         msg = f"🅇 Invalid! {err}"
     except Exception as err:
         msg = f"🅇 Failed to load {name!r}. {type(err).__name__}: {err}"
+        if debug:
+            raise
 
     typer.secho(msg, fg=typer.colors.GREEN if valid else typer.colors.RED, bold=True)
 

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -352,11 +352,11 @@ class PluginManifest(BaseModel):
                 return PluginManifest.from_distribution(str(package_or_filename))
             except ValidationError:
                 raise
-            except Exception:
+            except Exception as e:
                 raise ValueError(
                     f"Could not find manifest for {package_or_filename!r} as either a "
                     "package name or a file.."
-                )
+                ) from e
 
     ValidationError = ValidationError  # for convenience of access
 


### PR DESCRIPTION
Trying to validate Npe2-tester, the contribute/contributions leads to a
message about not  being able to find the file, instead of a proper
validation error.

This help printing the error message until this is properly fixed.