### PR TITLE
PackageMetadata field

### DIFF
--- a/npe2/_from_npe1.py
+++ b/npe2/_from_npe1.py
@@ -108,9 +108,6 @@ def manifest_from_npe1(
 
     return PluginManifest(
         name=package,
-        author=standard_meta.get("author"),
-        description=standard_meta.get("summary"),
-        version=standard_meta.get("version"),
         contributions=dict(parser.contributions),
     )
 

--- a/npe2/manifest/package_metadata.py
+++ b/npe2/manifest/package_metadata.py
@@ -1,5 +1,10 @@
 import email.message
-from importlib.metadata import metadata
+
+try:
+    from importlib.metadata import metadata
+except ImportError:
+    from importlib_metadata import metadata  # type: ignore
+
 from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, constr

--- a/npe2/manifest/package_metadata.py
+++ b/npe2/manifest/package_metadata.py
@@ -170,7 +170,7 @@ class PackageMetadata(BaseModel):
         return cls.from_dist_metadata(metadata(name))
 
     @classmethod
-    def from_dist_metadata(cls, meta: email.message.Message) -> "PackageMetadata":
+    def from_dist_metadata(cls, meta: "email.message.Message") -> "PackageMetadata":
         """Accepts importlib.metadata.Distribution.metadata"""
         manys = [f.name for f in cls.__fields__.values() if f.shape == SHAPE_LIST]
         d: Dict[str, Union[str, List[str]]] = {}

--- a/npe2/manifest/package_metadata.py
+++ b/npe2/manifest/package_metadata.py
@@ -1,15 +1,17 @@
-import email.message
-
 try:
     from importlib.metadata import metadata
 except ImportError:
     from importlib_metadata import metadata  # type: ignore
 
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, Extra, Field, constr
 from pydantic.fields import SHAPE_LIST
 from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    import email.message
+
 
 # https://packaging.python.org/specifications/core-metadata/
 
@@ -27,6 +29,9 @@ class PackageMetadata(BaseModel):
     The `importlib.metadata` provides the `metadata()` function,
     but it returns a somewhat awkward `email.message.Message` object.
     """
+
+    class Config:
+        extra = Extra.ignore
 
     metadata_version: MetadataVersion = Field(description="Version of the file format")
     name: PackageName = Field(  # type: ignore

--- a/npe2/manifest/package_metadata.py
+++ b/npe2/manifest/package_metadata.py
@@ -1,0 +1,177 @@
+import email.message
+from importlib.metadata import metadata
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, constr
+from pydantic.fields import SHAPE_LIST
+from typing_extensions import Literal
+
+# https://packaging.python.org/specifications/core-metadata/
+
+MetadataVersion = Literal["1.0", "1.1", "1.2", "2.0", "2.1", "2.2"]
+_alphanum = "[a-zA-Z0-9]"
+PackageName = constr(regex=f"^{_alphanum}[a-zA-Z0-9._-]*{_alphanum}$")
+
+
+class PackageMetadata(BaseModel):
+    """Pydantic model for standard python package metadata.
+
+    https://www.python.org/dev/peps/pep-0566/
+    https://packaging.python.org/specifications/core-metadata/
+
+    The `importlib.metadata` provides the `metadata()` function,
+    but it returns a somewhat awkward `email.message.Message` object.
+    """
+
+    metadata_version: MetadataVersion = Field(description="Version of the file format")
+    name: PackageName = Field(  # type: ignore
+        ...,
+        description="The name of the distribution. The name field "
+        "is the primary identifier for a distribution.",
+    )
+    # technically there is PackageVersion regex at
+    # https://www.python.org/dev/peps/pep-0440/#id81
+    # but it will fail on some dev versions, and it's not worth it.
+    version: str = Field(
+        ...,
+        description="A string containing the distribution’s version number. "
+        "This field must be in the format specified in PEP 440.",
+    )
+    dynamic: Optional[List[str]] = Field(
+        None,
+        description="A string containing the name of another core metadata "
+        "field. The field names Name and Version may not be specified in this field.",
+    )
+    platform: Optional[List[str]] = Field(
+        None,
+        description="A Platform specification describing an operating system "
+        "supported by the distribution which is not listed in the “Operating System” "
+        "Trove classifiers. See “Classifier” below.",
+    )
+    supported_platform: Optional[List[str]] = Field(
+        None,
+        description="Binary distributions containing a PKG-INFO file will use the "
+        "Supported-Platform field in their metadata to specify the OS and CPU for "
+        "which the binary distribution was compiled",
+    )
+    summary: Optional[str] = Field(
+        None, description="A one-line summary of what the distribution does."
+    )
+    description: Optional[str] = Field(
+        None,
+        description="A longer description of the distribution that can "
+        "run to several paragraphs.",
+    )
+    description_content_type: Optional[str] = Field(
+        None,
+        description="A string stating the markup syntax (if any) used in the "
+        "distribution’s description, so that tools can intelligently render the "
+        "description.",
+    )
+    keywords: Optional[str] = Field(
+        None,
+        description="A list of additional keywords, separated by commas, to be used "
+        "to assist searching for the distribution in a larger catalog.",
+    )
+    home_page: Optional[str] = Field(
+        None,
+        description="A string containing the URL for the distribution’s home page.",
+    )
+    download_url: Optional[str] = Field(
+        None,
+        description="A string containing the URL from which THIS version of the "
+        "distribution can be downloaded.",
+    )
+    author: Optional[str] = Field(
+        None,
+        description="A string containing the author’s name at a minimum; "
+        "additional contact information may be provided.",
+    )
+    author_email: Optional[str] = Field(
+        None,
+        description="A string containing the author’s e-mail address. It can contain "
+        "a name and e-mail address in the legal forms for a RFC-822 From: header.",
+    )
+    maintainer: Optional[str] = Field(
+        None,
+        description="A string containing the maintainer’s name at a minimum; "
+        "additional contact information may be provided.",
+    )
+    maintainer_email: Optional[str] = Field(
+        None,
+        description="A string containing the maintainer’s e-mail address. It can "
+        "contain a name and e-mail address in the legal forms for a "
+        "RFC-822 From: header.",
+    )
+    license: Optional[str] = Field(
+        None,
+        description="Text indicating the license covering the distribution where the "
+        "license is not a selection from the “License” Trove classifiers. See "
+        "“Classifier” below. This field may also be used to specify a particular "
+        "version of a license which is named via the Classifier field, or to "
+        "indicate a variation or exception to such a license.",
+    )
+    classifier: Optional[List[str]] = Field(
+        None,
+        description="Each entry is a string giving a single classification value for "
+        "the distribution. Classifiers are described in PEP 301, and the Python "
+        "Package Index publishes a dynamic list of currently defined classifiers.",
+    )
+    requires_dist: Optional[List[str]] = Field(
+        None,
+        description="The field format specification was relaxed to accept the syntax "
+        "used by popular publishing tools. Each entry contains a string naming some "
+        "other distutils project required by this distribution.",
+    )
+    requires_python: Optional[str] = Field(
+        None,
+        description="This field specifies the Python version(s) that the distribution "
+        "is guaranteed to be compatible with. Installation tools may look at this "
+        "when picking which version of a project to install. "
+        "The value must be in the format specified in Version specifiers (PEP 440).",
+    )
+    requires_external: Optional[List[str]] = Field(
+        None,
+        description="The field format specification was relaxed to accept the syntax "
+        "used by popular publishing tools. Each entry contains a string describing "
+        "some dependency in the system that the distribution is to be used. This "
+        "field is intended to serve as a hint to downstream project maintainers, and "
+        "has no semantics which are meaningful to the distutils distribution.",
+    )
+    project_url: Optional[List[str]] = Field(
+        None,
+        description="A string containing a browsable URL for the project and a label "
+        "for it, separated by a comma.",
+    )
+    provides_extra: Optional[List[str]] = Field(
+        None,
+        description="A string containing the name of an optional feature. Must be a "
+        "valid Python identifier. May be used to make a dependency conditional on "
+        "whether the optional feature has been requested.",
+    )
+
+    # rarely_used
+    provides_dist: Optional[List[str]] = None
+    obsoletes_dist: Optional[List[str]] = None
+
+    @classmethod
+    def for_package(cls, name: str) -> "PackageMetadata":
+        """Get PackageMetadata from a package name."""
+        return cls.from_dist_metadata(metadata(name))
+
+    @classmethod
+    def from_dist_metadata(cls, meta: email.message.Message) -> "PackageMetadata":
+        """Accepts importlib.metadata.Distribution.metadata"""
+        manys = [f.name for f in cls.__fields__.values() if f.shape == SHAPE_LIST]
+        d: Dict[str, Union[str, List[str]]] = {}
+        for key, value in meta.items():
+            key = _norm(key)
+            if key in manys:
+                d.setdefault(key, []).append(value)  # type: ignore
+            else:
+                d[key] = value
+        return cls.parse_obj(d)
+
+
+def _norm(string: str) -> str:
+    return string.replace("-", "_").replace(" ", "_").lower()

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -6,7 +6,6 @@ import types
 from contextlib import contextmanager
 from enum import Enum
 from importlib import import_module, util
-from importlib.metadata import Distribution
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
@@ -29,9 +28,9 @@ from .contributions import ContributionPoints
 from .package_metadata import PackageMetadata
 
 try:
-    from importlib.metadata import distributions
+    from importlib.metadata import Distribution, distributions
 except ImportError:
-    from importlib_metadata import distributions  # type: ignore
+    from importlib_metadata import Distribution, distributions  # type: ignore
 
 if TYPE_CHECKING:
     from importlib.metadata import EntryPoint

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -63,12 +63,6 @@ class PluginManifest(BaseModel):
         "package name for this plugin.",
     )
 
-    author: Optional[str] = Field(
-        None,
-        description="The author name(s). When unspecified, the description is "
-        "take from the 'Author' field of the package metadata.",
-    )
-
     display_name: str = Field(
         "",
         description="User-facing text to display as the name of this plugin",
@@ -98,21 +92,19 @@ class PluginManifest(BaseModel):
 
     @property
     def license(self) -> Optional[str]:
-        if self.package_metadata:
-            return self.package_metadata.license
-        return None
+        return self.package_metadata.license if self.package_metadata else None
 
     @property
     def version(self) -> Optional[str]:
-        if self.package_metadata:
-            return self.package_metadata.version
-        return None
+        return self.package_metadata.version if self.package_metadata else None
 
     @property
     def description(self) -> Optional[str]:
-        if self.package_metadata:
-            return self.package_metadata.summary
-        return None
+        return self.package_metadata.summary if self.package_metadata else None
+
+    @property
+    def author(self) -> Optional[str]:
+        return self.package_metadata.author if self.package_metadata else None
 
     @root_validator
     def _validate_root(cls, values: dict) -> dict:
@@ -335,8 +327,8 @@ class PluginManifest(BaseModel):
                     meta = PackageMetadata.from_dist_metadata(distribution.metadata)
                     mf.package_metadata = meta
 
-                    # populate missing metadata
                     mf.name = mf.name or meta.name  # should we assert?
+                    return mf
 
         raise FileNotFoundError(f"Could not find file {fname!r} in module {module!r}")
 

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -326,7 +326,7 @@ class PluginManifest(BaseModel):
                     meta = PackageMetadata.from_dist_metadata(distribution.metadata)
                     mf.package_metadata = meta
 
-                    mf.name = mf.name or meta.name  # should we assert?
+                    assert mf.name == meta.name, "Manifest name must match package name"
                     return mf
 
         raise FileNotFoundError(f"Could not find file {fname!r} in module {module!r}")

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -6,6 +6,7 @@ import types
 from contextlib import contextmanager
 from enum import Enum
 from importlib import import_module, util
+from importlib.metadata import Distribution
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
@@ -25,6 +26,7 @@ import yaml
 from pydantic import BaseModel, Extra, Field, ValidationError, root_validator
 
 from .contributions import ContributionPoints
+from .package_metadata import PackageMetadata
 
 try:
     from importlib.metadata import distributions
@@ -32,7 +34,6 @@ except ImportError:
     from importlib_metadata import distributions  # type: ignore
 
 if TYPE_CHECKING:
-    from email.message import Message
     from importlib.metadata import EntryPoint
 
 spdx_ids = (Path(__file__).parent / "spdx.txt").read_text().splitlines()
@@ -77,11 +78,6 @@ class PluginManifest(BaseModel):
         regex=r"^[^\W_][\w -~]{1,38}[^\W_]$",
     )
 
-    description: Optional[str] = Field(
-        description="A short description of what your extension is and does."
-        "When unspecified, the description is taken from package metadata."
-    )
-
     # TODO:
     # Perhaps we should version the plugin interface (not so the manifest, but
     # the actual mechanism/consumption of plugin information) independently
@@ -95,18 +91,28 @@ class PluginManifest(BaseModel):
         "the plugin's activate() function.",
     )
 
-    # this should come from setup.cfg ... but they don't require SPDX
-    license: Optional[SPDX] = None
-
-    version: Optional[str] = Field(
-        None,
-        description="SemVer compatible version. When unspecified the version "
-        "is taken from package metadata.",
-    )
-
     contributions: Optional[ContributionPoints]
 
     _manifest_file: Optional[Path] = None
+    package_metadata: Optional[PackageMetadata] = None
+
+    @property
+    def license(self) -> Optional[str]:
+        if self.package_metadata:
+            return self.package_metadata.license
+        return None
+
+    @property
+    def version(self) -> Optional[str]:
+        if self.package_metadata:
+            return self.package_metadata.version
+        return None
+
+    @property
+    def description(self) -> Optional[str]:
+        if self.package_metadata:
+            return self.package_metadata.summary
+        return None
 
     @root_validator
     def _validate_root(cls, values: dict) -> dict:
@@ -167,9 +173,7 @@ class PluginManifest(BaseModel):
         dist = distribution(name)  # may raise PackageNotFoundError
         for ep in dist.entry_points:
             if ep.group == ENTRY_POINT:
-                pm = PluginManifest._from_entrypoint(ep)
-                pm._populate_missing_meta(dist.metadata)
-                return pm
+                return PluginManifest._from_entrypoint(ep, dist)
         raise ValueError(
             "Distribution {name!r} exists but does not provide a napari manifest"
         )
@@ -249,17 +253,6 @@ class PluginManifest(BaseModel):
         if callable(getattr(mod, "deactivate", None)):
             return mod.deactivate(context)  # type: ignore
 
-    def _populate_missing_meta(self, metadata: Message):
-        """add missing items from an importlib metadata object"""
-        if not self.name:
-            self.name = metadata["Name"]
-        if not self.version:
-            self.version = metadata["Version"]
-        if not self.description:
-            self.description = metadata["Summary"]
-        if not self.license:
-            self.license = metadata["License"]
-
     @classmethod
     def discover(
         cls, entry_point_group: str = ENTRY_POINT, paths: Sequence[str] = ()
@@ -304,8 +297,7 @@ class PluginManifest(BaseModel):
                     if ep.group != entry_point_group:
                         continue
                     try:
-                        pm = cls._from_entrypoint(ep)
-                        pm._populate_missing_meta(dist.metadata)
+                        pm = cls._from_entrypoint(ep, dist)
                         yield DiscoverResults(pm, ep, None)
                     except ValidationError as e:
                         logger.warning(msg=f"Invalid schema {ep.value!r}")
@@ -318,7 +310,9 @@ class PluginManifest(BaseModel):
                         yield DiscoverResults(None, ep, e)
 
     @classmethod
-    def _from_entrypoint(cls, entry_point: EntryPoint) -> PluginManifest:
+    def _from_entrypoint(
+        cls, entry_point: EntryPoint, distribution: Optional[Distribution] = None
+    ) -> PluginManifest:
 
         match = entry_point.pattern.match(entry_point.value)  # type: ignore
         module = match.group("module")
@@ -334,9 +328,16 @@ class PluginManifest(BaseModel):
         fname = match.group("attr")
 
         for loc in spec.submodule_search_locations or []:
-            mf = Path(loc) / fname
-            if mf.exists():
-                return PluginManifest.from_file(mf)
+            mf_file = Path(loc) / fname
+            if mf_file.exists():
+                mf = PluginManifest.from_file(mf_file)
+                if distribution is not None:
+                    meta = PackageMetadata.from_dist_metadata(distribution.metadata)
+                    mf.package_metadata = meta
+
+                    # populate missing metadata
+                    mf.name = mf.name or meta.name  # should we assert?
+
         raise FileNotFoundError(f"Could not find file {fname!r} in module {module!r}")
 
     @classmethod

--- a/tests/test_npe2.py
+++ b/tests/test_npe2.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from npe2 import PluginManager, PluginManifest
 from npe2.cli import main
+from npe2.manifest.package_metadata import PackageMetadata
 
 
 def test_schema():
@@ -37,6 +38,16 @@ def test_discover(uses_sample_plugin):
     assert entrypoint and entrypoint.group == "napari.manifest"
     assert entrypoint.value == "my_plugin:napari.yaml"
     assert error is None
+
+
+def test_package_meta(uses_sample_plugin):
+    direct_meta = PackageMetadata.for_package("my_plugin")
+    assert direct_meta.name == "my_plugin"
+    assert direct_meta.version == "1.2.3"
+    discover_results = list(PluginManifest.discover())
+    [(manifest, *_)] = discover_results
+    assert manifest
+    assert manifest.package_metadata == direct_meta
 
 
 def test_cli(monkeypatch, sample_path):
@@ -117,7 +128,6 @@ def _mutator_writer_invalid_file_extension_1(data):
 
 
 def _mutator_writer_invalid_file_extension_2(data):
-    print(f'HERE {data["contributions"]["writers"][0]["filename_extensions"]}')
     data["contributions"]["writers"][0]["filename_extensions"] = ["."]
     return data
 

--- a/tests/test_npe2.py
+++ b/tests/test_npe2.py
@@ -50,6 +50,20 @@ def test_package_meta(uses_sample_plugin):
     assert manifest.package_metadata == direct_meta
 
 
+def test_all_package_meta():
+    """make sure PackageMetadata works for whatever packages are in the environment.
+
+    just a brute force way to get a little more validation coverage
+    """
+    try:
+        from importlib.metadata import distributions
+    except ImportError:
+        from importlib_metadata import distributions  # type: ignore
+
+    for d in distributions():
+        assert PackageMetadata.from_dist_metadata(d.metadata)
+
+
 def test_cli(monkeypatch, sample_path):
     cmd = ["npe2", "validate", str(sample_path / "my_plugin" / "napari.yaml")]
     monkeypatch.setattr(sys, "argv", cmd)


### PR DESCRIPTION
this adds a PackageMetadata model, basically just a nicer object than the `email.message.Message` that comes from `importlib.metadata.Distribution`.

Adhere's strictly to PEP 566 and https://packaging.python.org/specifications/core-metadata/