### PR TITLE
Delay import of `cmd.python_name` until needed

### DIFF
--- a/npe2/_command_registry.py
+++ b/npe2/_command_registry.py
@@ -2,58 +2,104 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional, Union
 
 PDisposable = Callable[[], None]
+import re
+from dataclasses import dataclass
+from importlib import import_module
 
 from psygnal import Signal
+
+from .manifest.commands import _dotted_name
+
+_dotted_name_pattrn = re.compile(_dotted_name)
+
+
+@dataclass
+class CommandHandler:
+    id: str
+    function: Optional[Callable] = None
+    python_name: Optional[str] = None
+
+    def resolve(self) -> Callable:
+        if self.function is not None:
+            return self.function
+        if self.python_name is None:
+            raise RuntimeError("cannot resolve command without python_name")
+
+        try:
+            module_name, class_name = self.python_name.rsplit(":", 1)
+            module = import_module(module_name)
+            self.function = getattr(module, class_name)
+        except Exception as e:
+            raise RuntimeError("Failed to import command at {self.python_name!r}: {e}")
+        return self.function
 
 
 class CommandRegistry:
     commandRegistered = Signal(str)
+    commandUnregistered = Signal(str)
 
     def __init__(self) -> None:
-        self._commands: Dict[str, Callable] = {}
+        self._commands: Dict[str, CommandHandler] = {}
 
     # similar to:
     # https://github.com/microsoft/vscode/blob/main/src/vs/platform/commands/common/commands.ts#L61
-    def register(self, id: str, command: Callable) -> PDisposable:
-        if not isinstance(id, str) and id.strip():
+    def register(self, id: str, command: Union[Callable, str]) -> PDisposable:
+        """Register a command under `id`.
+
+        Parameters
+        ----------
+        id : str
+            A unique key with which to refer to this command
+        command : Union[Callable, str]
+            Either a callable object, or (if a string) the fully qualified name of a
+            python object.  If a string is provided, it is not imported until
+            the command is actually executed.
+
+        Returns
+        -------
+        PDisposable
+            A callable that, when called, unregisters the command.
+
+        Raises
+        ------
+        ValueError
+            If the id is not a non-empty string, or if it already exists.
+        TypeError
+            If `command` is not a string or a callable object.
+        """
+        if not (isinstance(id, str) and id.strip()):
             raise ValueError(
                 f"Invalid command id for {command}, must be non-empty string"
             )
         if id in self._commands:
             raise ValueError(f"Command {id} already exists")
-        if not callable(command):
+
+        if isinstance(command, str):
+            if not _dotted_name_pattrn.match(command):
+                raise ValueError(
+                    "String command {command!r} is not a valid qualified python path."
+                )
+            cmd = CommandHandler(id, python_name=command)
+        elif not callable(command):
             raise TypeError(f"Cannot register non-callable command: {command}")
+        else:
+            cmd = CommandHandler(id, function=command)
 
         # TODO: validate arguments and type constraints
         # possibly wrap command in a type validator?
 
-        self._commands[id] = command
+        self._commands[id] = cmd
         self.commandRegistered.emit(id)
 
         return partial(self.unregister, id)
 
-    def _register_python_name(self, id: str, python_name: str) -> PDisposable:
-        """Register a fully qualified `python_name` as command `id`
-
-        Parameters
-        ----------
-        id : str
-            Command id to register
-        python_name : str
-            Fully qualified name to python object (e.g. `my_package.submodule.function`)
-        """
-        from importlib import import_module
-
-        module_name, class_name = python_name.rsplit(":", 1)
-        module = import_module(module_name)
-        function = getattr(module, class_name)
-        return self.register(id, function)
-
     def unregister(self, id: str):
-        self._commands.pop(id, None)
+        if id in self._commands:
+            del self._commands[id]
+            self.commandUnregistered.emit(id)
 
     def get(self, id: str) -> Callable:
         # FIXME: who should control activation?
@@ -65,9 +111,9 @@ class CommandRegistry:
             if id in pm._contrib._commands:
                 _, plugin_key = pm._contrib._commands[id]
                 pm.activate(plugin_key)
-        if id not in self._commands:
-            raise KeyError(f"command {id!r} not registered")
-        return self._commands[id]
+            if id not in self._commands:
+                raise KeyError(f"command {id!r} not registered")
+        return self._commands[id].resolve()
 
     def execute(self, id: str, args=(), kwargs={}) -> Any:
         return self.get(id)(*args, **kwargs)

--- a/npe2/_command_registry.py
+++ b/npe2/_command_registry.py
@@ -38,8 +38,8 @@ class CommandHandler:
 
 
 class CommandRegistry:
-    commandRegistered = Signal(str)
-    commandUnregistered = Signal(str)
+    command_registered = Signal(str)
+    command_unregistered = Signal(str)
 
     def __init__(self) -> None:
         self._commands: Dict[str, CommandHandler] = {}
@@ -90,7 +90,7 @@ class CommandRegistry:
         # possibly wrap command in a type validator?
 
         self._commands[id] = cmd
-        self.commandRegistered.emit(id)
+        self.command_registered.emit(id)
 
         return partial(self.unregister, id)
 
@@ -98,7 +98,7 @@ class CommandRegistry:
         """Unregister command with key `id`.  No-op if key doesn't exist."""
         if id in self._commands:
             del self._commands[id]
-            self.commandUnregistered.emit(id)
+            self.command_unregistered.emit(id)
 
     def get(self, id: str) -> Callable:
         """Get callable object for command `id`."""

--- a/npe2/_command_registry.py
+++ b/npe2/_command_registry.py
@@ -44,8 +44,6 @@ class CommandRegistry:
     def __init__(self) -> None:
         self._commands: Dict[str, CommandHandler] = {}
 
-    # similar to:
-    # https://github.com/microsoft/vscode/blob/main/src/vs/platform/commands/common/commands.ts#L61
     def register(self, id: str, command: Union[Callable, str]) -> PDisposable:
         """Register a command under `id`.
 

--- a/npe2/_command_registry.py
+++ b/npe2/_command_registry.py
@@ -95,11 +95,13 @@ class CommandRegistry:
         return partial(self.unregister, id)
 
     def unregister(self, id: str):
+        """Unregister command with key `id`.  No-op if key doesn't exist."""
         if id in self._commands:
             del self._commands[id]
             self.commandUnregistered.emit(id)
 
     def get(self, id: str) -> Callable:
+        """Get callable object for command `id`."""
         # FIXME: who should control activation?
         if id not in self._commands:
             from ._plugin_manager import PluginManager

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -172,7 +172,7 @@ class PluginManager:
             return ctx
 
         try:
-            mf._call_func_in_plugin_entrypoint("activate", (ctx))
+            mf._call_func_in_plugin_entrypoint("activate", args=(ctx,))
             ctx._activated = True
         except Exception as e:  # pragma: no cover
             self._contexts.pop(key, None)
@@ -190,7 +190,7 @@ class PluginManager:
             return
         mf = self._manifests[key]
         ctx = self._contexts.pop(key)
-        mf._call_func_in_plugin_entrypoint("deactivate", (ctx))
+        mf._call_func_in_plugin_entrypoint("deactivate", args=(ctx,))
         ctx._dispose()
 
     def iter_compatible_readers(

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -178,7 +178,6 @@ class PluginManager:
             self._contexts.pop(key, None)
             raise type(e)(f"Activating plugin {key!r} failed: {e}") from e
 
-        # Note: this could also be delayed until the command is actually called.
         if mf.contributions and mf.contributions.commands:
             for cmd in mf.contributions.commands:
                 if cmd.python_name and cmd.id not in self.commands:

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -182,7 +182,7 @@ class PluginManager:
         if mf.contributions and mf.contributions.commands:
             for cmd in mf.contributions.commands:
                 if cmd.python_name and cmd.id not in self.commands:
-                    self.commands._register_python_name(cmd.id, cmd.python_name)
+                    self.commands.register(cmd.id, cmd.python_name)
 
         return ctx
 

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -172,7 +172,7 @@ class PluginManager:
             return ctx
 
         try:
-            mf.activate(ctx)
+            mf._call_func_in_plugin_entrypoint("activate", (ctx))
             ctx._activated = True
         except Exception as e:  # pragma: no cover
             self._contexts.pop(key, None)
@@ -188,9 +188,9 @@ class PluginManager:
     def deactivate(self, key: PluginName) -> None:
         if key not in self._contexts:
             return
-        plugin = self._manifests[key]
-        plugin.deactivate()
+        mf = self._manifests[key]
         ctx = self._contexts.pop(key)
+        mf._call_func_in_plugin_entrypoint("deactivate", (ctx))
         ctx._dispose()
 
     def iter_compatible_readers(

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,5 +1,6 @@
 import pytest
 
+from npe2._command_registry import CommandHandler, CommandRegistry
 from npe2._plugin_manager import PluginManager
 
 
@@ -34,3 +35,43 @@ def test_plugin_manager(sample_path):
     assert "my_plugin" not in pm._contexts
     pm.deactivate("my_plugin")  # second time is a no-op
     assert "my_plugin" not in pm._contexts
+
+
+def test_command_handler():
+    with pytest.raises(RuntimeError):
+        # cannot resolve something without either a python_name or function
+        CommandHandler("hi").resolve()
+
+    with pytest.raises(RuntimeError):
+        # cannot resolve something without either a python_name or function
+        CommandHandler("hi", python_name="cannot.import.this").resolve()
+
+
+def test_command_reg_register():
+    reg = CommandRegistry()
+    with pytest.raises(ValueError):
+        # must register non empty string id
+        reg.register(1, lambda: None)  # type: ignore
+    with pytest.raises(TypeError):
+        # neither a string or a callable
+        reg.register("other.id", 8)  # type: ignore
+
+    with pytest.raises(ValueError):
+        # must register non empty string id
+        reg.register("some.id", "1_is_not.a_valid_python_name")
+    reg.register("some.id", "this.is.a_valid_python_name")
+
+    with pytest.raises(ValueError):
+        # already registered
+        reg.register("some.id", "this.is.a_valid_python_name")
+
+
+def test_command_reg_get():
+    def f(x, y):
+        return x + y
+
+    reg = CommandRegistry()
+    reg.register("id", f)
+    assert "id" in reg
+    assert reg.get("id") is f
+    assert reg.execute("id", (1, 2)) == 3


### PR DESCRIPTION
Small improvement here: currently, `python_name` commands are imported upon plugin activation.  This PR makes it so that they are not resolved until someone calls `command_registry.get()` for the corresponding command id.