### PR TITLE
Start to make command APIs clearer

### DIFF
--- a/npe2/_from_npe1.py
+++ b/npe2/_from_npe1.py
@@ -64,9 +64,6 @@ for m in dir(HookSpecs):
         setattr(HookSpecs, m, napari_hook_specification(getattr(HookSpecs, m)))
 
 
-WidgetCallable = Union[Callable, Tuple[Callable, dict]]
-
-
 @dataclass
 class PluginPackage:
     package_name: str
@@ -284,6 +281,7 @@ class HookImplParser:
                 warnings.warn(msg)
 
     def napari_experimental_provide_dock_widget(self, impl: HookImplementation):
+        WidgetCallable = Union[Callable, Tuple[Callable, dict]]
         items: Union[WidgetCallable, List[WidgetCallable]] = impl.function()
         if not isinstance(items, list):
             items = [items]  # pragma: no cover

--- a/npe2/_from_npe1.py
+++ b/npe2/_from_npe1.py
@@ -6,7 +6,6 @@ import warnings
 from configparser import ConfigParser
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from typing import (
     Any,
@@ -139,7 +138,7 @@ def norm_plugin_name(plugin_name: Optional[str] = None, module: Any = None) -> s
     msg = f"We tried hard! but could not detect a plugin named {plugin_name!r}."
     if plugin_manager.plugins:
         msg += f" Plugins found include: {list(plugin_manager.plugins)}"
-    raise PackageNotFoundError(msg)
+    raise metadata.PackageNotFoundError(msg)
 
 
 def manifest_from_npe1(

--- a/npe2/_types.py
+++ b/npe2/_types.py
@@ -54,11 +54,13 @@ ReaderGetter = Callable[[Union[str, List[str]]], Optional[ReaderFunction]]
 # SampleDataGenerator.command must point to a SampleDataCreator
 SampleDataCreator = Callable[..., List[LayerData]]
 
-# WriterContribution.command must point to a WriterFunction
-# Writers that take at most one layer must provide a SingleWriterFunction command.
-# Otherwise, they must provide a MultiWriterFunction.
-# where the number of layers they take is defined as
-# n = sum(ltc.max() for ltc in WriterContribution.layer_type_constraints())
+# WriterContribution.command must point to a WriterFunction.
+# Currently, two calling conventions are supported for writers: single-layer and
+# multi-layer writers. When at most one layer can be matched by a writer, it
+# must use the single-layer convention. Otherwise, the multi-layer convention
+# must be used. WriterFunctions are only called when the set of layers to be
+# written satisfies a set of layer-type constraints specified by
+# WriterContribution.layer_types.layer_type_constraints().
 SingleWriterFunction = Callable[[str, DataType, Metadata], List[str]]
 MultiWriterFunction = Callable[[str, List[FullLayerData]], List[str]]
 WriterFunction = Union[SingleWriterFunction, MultiWriterFunction]

--- a/npe2/_types.py
+++ b/npe2/_types.py
@@ -1,12 +1,21 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from typing_extensions import Literal, Protocol
 
 if TYPE_CHECKING:
+    import magicgui.widgets
     import numpy as np
-    from magicgui.widgets import FunctionGui
-    from qtpy.QtWidgets import QWidget
+    import qtpy.QtWidgets
+
+
+# General types
+
+PathLike = Union[str, Path]
+PathOrPaths = Union[PathLike, Sequence[PathLike]]
+
+
+# Layer-related types
 
 
 class ArrayLike(Protocol):
@@ -31,9 +40,28 @@ Metadata = Dict
 DataType = Union[ArrayLike, Sequence[ArrayLike]]
 FullLayerData = Tuple[DataType, Metadata, LayerName]
 LayerData = Union[Tuple[DataType], Tuple[DataType, Metadata], FullLayerData]
-PathLike = Union[str, Path]
-PathOrPaths = Union[PathLike, Sequence[PathLike]]
+
+# ########################## CONTRIBUTIONS #################################
+
+# WidgetContribution.command must point to a WidgetCreator
+Widget = Union["magicgui.widgets.Widget", "qtpy.QtWidgets.QWidget"]
+WidgetCreator = Callable[..., Widget]
+
+# ReaderContribution.command must point to a ReaderGetter
 ReaderFunction = Callable[[PathOrPaths], List[LayerData]]
-WriterFunction = Callable[[str, List[FullLayerData]], List[str]]
-Widget = Union["FunctionGui", "QWidget"]
-WidgetCallable = Callable[..., Widget]
+ReaderGetter = Callable[[Union[str, List[str]]], Optional[ReaderFunction]]
+
+# SampleDataGenerator.command must point to a SampleDataCreator
+SampleDataCreator = Callable[..., List[LayerData]]
+
+# WriterContribution.command must point to a WriterFunction
+# Writers that take at most one layer must provide a SingleWriterFunction command.
+# Otherwise, they must provide a MultiWriterFunction.
+# where the number of layers they take is defined as
+# n = sum(ltc.max() for ltc in WriterContribution.layer_type_constraints())
+# @nclack, please check ... and let's see if we can make that clearer in the docstrings
+SingleWriterFunction = Callable[[str, DataType, Metadata], List[str]]
+MultiWriterFunction = Callable[[str, List[FullLayerData]], List[str]]
+WriterFunction = Union[SingleWriterFunction, MultiWriterFunction]
+
+# ##########################################################################

--- a/npe2/_types.py
+++ b/npe2/_types.py
@@ -59,7 +59,6 @@ SampleDataCreator = Callable[..., List[LayerData]]
 # Otherwise, they must provide a MultiWriterFunction.
 # where the number of layers they take is defined as
 # n = sum(ltc.max() for ltc in WriterContribution.layer_type_constraints())
-# @nclack, please check ... and let's see if we can make that clearer in the docstrings
 SingleWriterFunction = Callable[[str, DataType, Metadata], List[str]]
 MultiWriterFunction = Callable[[str, List[FullLayerData]], List[str]]
 WriterFunction = Union[SingleWriterFunction, MultiWriterFunction]

--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union, overload
 from typing_extensions import Literal
 
 from . import PluginManager
-from ._types import FullLayerData, LayerData, PathLike
+from .types import FullLayerData, LayerData, PathLike
 
 if TYPE_CHECKING:
     from .manifest.io import ReaderContribution, WriterContribution

--- a/npe2/manifest/io.py
+++ b/npe2/manifest/io.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Extra, Field, validator
 
-from .._types import ReaderFunction
+from ..types import ReaderFunction
 from .utils import Executable
 
 

--- a/npe2/manifest/sample_data.py
+++ b/npe2/manifest/sample_data.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from pydantic import BaseModel
 from pydantic.fields import Field
 
-from .._types import LayerData
+from ..types import LayerData
 from .utils import Executable
 
 if TYPE_CHECKING:

--- a/npe2/manifest/widgets.py
+++ b/npe2/manifest/widgets.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from pydantic import BaseModel, Extra, Field
 
-from .._types import Widget
+from ..types import Widget
 from .utils import Executable
 
 if TYPE_CHECKING:

--- a/npe2/types.py
+++ b/npe2/types.py
@@ -54,13 +54,11 @@ ReaderGetter = Callable[[Union[str, List[str]]], Optional[ReaderFunction]]
 # SampleDataGenerator.command must point to a SampleDataCreator
 SampleDataCreator = Callable[..., List[LayerData]]
 
-# WriterContribution.command must point to a WriterFunction.
-# Currently, two calling conventions are supported for writers: single-layer and
-# multi-layer writers. When at most one layer can be matched by a writer, it
-# must use the single-layer convention. Otherwise, the multi-layer convention
-# must be used. WriterFunctions are only called when the set of layers to be
-# written satisfies a set of layer-type constraints specified by
-# WriterContribution.layer_types.layer_type_constraints().
+# WriterContribution.command must point to a WriterFunction
+# Writers that take at most one layer must provide a SingleWriterFunction command.
+# Otherwise, they must provide a MultiWriterFunction.
+# where the number of layers they take is defined as
+# n = sum(ltc.max() for ltc in WriterContribution.layer_type_constraints())
 SingleWriterFunction = Callable[[str, DataType, Metadata], List[str]]
 MultiWriterFunction = Callable[[str, List[FullLayerData]], List[str]]
 WriterFunction = Union[SingleWriterFunction, MultiWriterFunction]

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
-from npe2._types import FullLayerData
 from npe2.io_utils import read, read_get_reader, write
+from npe2.types import FullLayerData
 
 
 def test_read(uses_sample_plugin):


### PR DESCRIPTION
the parallel of hook_specifications.py for npe2.  Not sure yet were to surface/use these things, but we definitely need them somewhere.

note, this pr also makes npe2.types public