### PR TITLE
change engine to schema_version

### DIFF
--- a/tests/test_npe2.py
+++ b/tests/test_npe2.py
@@ -152,8 +152,8 @@ def _mutator_writer_invalid_file_extension_2(data):
     return data
 
 
-def _mutator_engine_version_too_high(data):
-    data["engine"] = "999.999.999"
+def _mutator_schema_version_too_high(data):
+    data["schema"] = "999.999.999"
     return data
 
 
@@ -170,7 +170,7 @@ def _mutator_engine_version_too_high(data):
         _mutator_writer_invalid_layer_type_constraint,
         _mutator_writer_invalid_file_extension_1,
         _mutator_writer_invalid_file_extension_2,
-        _mutator_engine_version_too_high,
+        _mutator_schema_version_too_high,
     ],
 )
 def test_invalid(mutator, uses_sample_plugin):


### PR DESCRIPTION
closes #64 

renames `manifest.engine` to `manifest.schema_version`