### PR TITLE
Extract out ImportExport logic from PluginManifest, don't sort yaml fields alphabetically

### DIFF
--- a/npe2/manifest/_bases.py
+++ b/npe2/manifest/_bases.py
@@ -1,0 +1,113 @@
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Dict, Optional, Union
+
+import pytomlpp as toml
+import yaml
+from pydantic import BaseModel, PrivateAttr
+
+
+class ImportExportModel(BaseModel):
+    """Model mixin/base class that provides read/write from toml/yaml/json.
+
+    To force the inclusion of a given field in the exported toml/yaml use:
+
+        class MyModel(ImportExportModel):
+            some_field: str = Field(..., always_export=True)
+    """
+
+    _source_file: Optional[Path] = PrivateAttr(None)
+
+    def toml(self, pyproject=False, **kwargs) -> str:
+        """Generate serialized `toml` string for this model.
+
+        Parameters
+        ----------
+        pyproject : bool, optional
+            If `True`, output will be in pyproject format, with all data under
+            `tool.napari`, by default `False`.
+        **kwargs
+            passed to `BaseModel.json()`
+        """
+        d = self._serialized_data(**kwargs)
+        if pyproject:
+            d = {"tool": {"napari": d}}
+        return toml.dumps(d)
+
+    def yaml(self, **kwargs) -> str:
+        """Generate serialized `yaml` string for this model.
+
+        Parameters
+        ----------
+        **kwargs
+            passed to `BaseModel.json()`
+        """
+        return yaml.safe_dump(self._serialized_data(**kwargs), sort_keys=False)
+
+    @classmethod
+    def from_file(cls, path: Union[Path, str]) -> "ImportExportModel":
+        """Parse model from a metadata file.
+
+        Parameters
+        ----------
+        path : Path or str
+            Path to file.  Must have extension {'.json', '.yaml', '.yml', '.toml'}
+
+        Returns
+        -------
+        object
+            The parsed model.
+
+        Raises
+        ------
+        FileNotFoundError
+            If `path` does not exist.
+        ValueError
+            If the file extension is not in {'.json', '.yaml', '.yml', '.toml'}
+        """
+        path = Path(path).expanduser().absolute().resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        loader: Callable
+        if path.suffix.lower() == ".json":
+            loader = json.load
+        elif path.suffix.lower() == ".toml":
+            loader = toml.load
+        elif path.suffix.lower() in (".yaml", ".yml"):
+            loader = yaml.safe_load
+        else:
+            raise ValueError(f"unrecognized file extension: {path}")
+
+        with open(path) as f:
+            data = loader(f) or {}
+
+        if path.name == "pyproject.toml":
+            data = data["tool"]["napari"]
+
+        obj = cls(**data)
+        obj._source_file = Path(path).expanduser().absolute().resolve()
+        return obj
+
+    def _serialized_data(self, **kwargs):
+        """using json encoders for all outputs"""
+        kwargs.setdefault("exclude_unset", True)
+        with self._required_export_fields_set():
+            return json.loads(self.json(**kwargs))
+
+    @contextmanager
+    def _required_export_fields_set(self):
+        fields = self.__fields__.items()
+        required = {k for k, v in fields if v.field_info.extra.get("always_export")}
+
+        was_there: Dict[str, bool] = {}
+        for f in required:
+            was_there[f] = f in self.__fields_set__
+            self.__fields_set__.add(f)
+        try:
+            yield
+        finally:
+            for f in required:
+                if not was_there.get(f):
+                    self.__fields_set__.discard(f)


### PR DESCRIPTION
This pulls out two things from #63 that are generally useful and I'd like to get in:

1. It extracts the TOML/YAML read/write logic so that it is less intertwined with the PluginManifest fields, and so that it can be reused (this is useful for generating "sub" examples of, for instance, just a single contribution).
2. It turns off the default `sort_keys` behavior on `yaml.safe_dump`, so that keys appear in the output YAML in the order that they were declared in the model.
