### PR TITLE
split contributions/io into readers and writers

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -26,13 +26,13 @@ from intervaltree import IntervalTree
 
 from ._command_registry import CommandRegistry
 from .manifest import PluginManifest, _validators
-from .manifest.io import LayerType
+from .manifest.writers import LayerType, WriterContribution
 
 if TYPE_CHECKING:
     from .manifest.commands import CommandContribution
     from .manifest.contributions import ContributionPoints
-    from .manifest.io import ReaderContribution, WriterContribution
     from .manifest.menus import MenuItem
+    from .manifest.readers import ReaderContribution
     from .manifest.sample_data import SampleDataContribution
     from .manifest.submenu import SubmenuContribution
     from .manifest.themes import ThemeContribution

--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -8,7 +8,8 @@ from . import PluginManager
 from .types import FullLayerData, LayerData, PathLike
 
 if TYPE_CHECKING:
-    from .manifest.io import ReaderContribution, WriterContribution
+    from .manifest.readers import ReaderContribution
+    from .manifest.writers import WriterContribution
 
 
 def read(path: PathLike, *, plugin_name: Optional[str] = None) -> List[LayerData]:

--- a/npe2/manifest/contributions.py
+++ b/npe2/manifest/contributions.py
@@ -3,16 +3,12 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from .commands import CommandContribution
-
-# from .keybindings import KeyBindingContribution
 from .menus import MenusContribution
 from .readers import ReaderContribution
 from .sample_data import SampleDataContribution
 from .submenu import SubmenuContribution
 from .themes import ThemeContribution
 from .widgets import WidgetContribution
-
-# from .configuration import JsonSchemaObject
 from .writers import WriterContribution
 
 

--- a/npe2/manifest/contributions.py
+++ b/npe2/manifest/contributions.py
@@ -4,15 +4,16 @@ from pydantic import BaseModel
 
 from .commands import CommandContribution
 
-# from .configuration import JsonSchemaObject
-from .io import ReaderContribution, WriterContribution
-
 # from .keybindings import KeyBindingContribution
 from .menus import MenusContribution
+from .readers import ReaderContribution
 from .sample_data import SampleDataContribution
 from .submenu import SubmenuContribution
 from .themes import ThemeContribution
 from .widgets import WidgetContribution
+
+# from .configuration import JsonSchemaObject
+from .writers import WriterContribution
 
 
 class ContributionPoints(BaseModel):

--- a/npe2/manifest/readers.py
+++ b/npe2/manifest/readers.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Extra, Field
+
+from ..types import ReaderFunction
+from .utils import Executable
+
+
+class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
+    command: str = Field(
+        ..., description="Identifier of the command providing `napari_get_reader`."
+    )
+    filename_patterns: List[str] = Field(
+        ...,
+        description="List of filename patterns (for fnmatch) that this reader can "
+        "accept. Reader will be tried only if `fnmatch(filename, pattern) == True`. "
+        "Use `['*']` to match all filenames.",
+    )
+    accepts_directories: bool = Field(
+        False, description="Whether this reader accepts directories"
+    )
+
+    class Config:
+        extra = Extra.forbid

--- a/npe2/manifest/writers.py
+++ b/npe2/manifest/writers.py
@@ -1,28 +1,9 @@
 from enum import Enum
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from pydantic import BaseModel, Extra, Field, validator
 
-from ..types import ReaderFunction
 from .utils import Executable
-
-
-class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
-    command: str = Field(
-        ..., description="Identifier of the command providing `napari_get_reader`."
-    )
-    filename_patterns: List[str] = Field(
-        ...,
-        description="List of filename patterns (for fnmatch) that this reader can "
-        "accept. Reader will be tried only if `fnmatch(filename, pattern) == True`. "
-        "Use `['*']` to match all filenames.",
-    )
-    accepts_directories: bool = Field(
-        False, description="Whether this reader accepts directories"
-    )
-
-    class Config:
-        extra = Extra.forbid
 
 
 class LayerType(str, Enum):


### PR DESCRIPTION
`contributions/io.py`, unlike all other contributions, has two classes (readers and writers).  I frequently get tripped up by that when I'm searching files, and would like to standardize it to be like the rest