### PR TITLE
change sample plugin name from `my_plugin` to `my-plugin`

### DIFF
--- a/tests/sample/my_plugin-1.2.3.dist-info/METADATA
+++ b/tests/sample/my_plugin-1.2.3.dist-info/METADATA
@@ -1,5 +1,5 @@
 Metadata-Version: 2.1
-Name: my_plugin
+Name: my-plugin
 Version: 1.2.3
 Summary: My napari plugin
 License: BSD-3

--- a/tests/sample/my_plugin-1.2.3.dist-info/entry_points.txt
+++ b/tests/sample/my_plugin-1.2.3.dist-info/entry_points.txt
@@ -1,2 +1,2 @@
 [napari.manifest]
-my_plugin = my_plugin:napari.yaml
+my-plugin = my_plugin:napari.yaml

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -1,32 +1,32 @@
-name: my_plugin
+name: my-plugin
 display_name: My Plugin
 on_activate: my_plugin:activate
 on_deactivate: my_plugin:deactivate
 contributions:
   commands:
-    - id: my_plugin.hello_world
+    - id: my-plugin.hello_world
       title: Hello World
-    - id: my_plugin.another_command
+    - id: my-plugin.another_command
       title: Another Command
-    - id: my_plugin.some_reader
+    - id: my-plugin.some_reader
       title: Some Reader
       python_name: my_plugin:get_reader
-    - id: my_plugin.url_reader
+    - id: my-plugin.url_reader
       title: URL Reader
       python_name: my_plugin:url_reader
-    - id: my_plugin.my_writer
+    - id: my-plugin.my_writer
       title: My Multi-layer Writer
       python_name: my_plugin:writer_function
-    - id: my_plugin.my_single_writer
+    - id: my-plugin.my_single_writer
       title: My single-layer Writer
       python_name: my_plugin:writer_function_single
-    - id: my_plugin.generate_random_data
+    - id: my-plugin.generate_random_data
       title: Generate uniform random data
       python_name: my_plugin:random_data
-    - id: my_plugin.some_widget
+    - id: my-plugin.some_widget
       title: Create my widget
       python_name: my_plugin:SomeWidget
-    - id: my_plugin.some_function_widget
+    - id: my-plugin.some_function_widget
       title: Create widget from my function
       python_name: my_plugin:make_widget_from_function
   configuration: # call it settings?
@@ -37,36 +37,36 @@ contributions:
         title: Load lazily
         description: Whether to load images lazily with dask
   readers:
-    - command: my_plugin.some_reader
+    - command: my-plugin.some_reader
       filename_patterns: ["*.fzy", "*.fzzy"]
       accepts_directories: true
-    - command: my_plugin.url_reader
+    - command: my-plugin.url_reader
       filename_patterns: ["http://*", "https://*"]
       accepts_directories: false
   writers:
-    - command: my_plugin.my_writer
+    - command: my-plugin.my_writer
       filename_extensions: ["*.tif", "*.tiff"]
       layer_types: ["image{2,4}", "tracks?"]
-    - command: my_plugin.my_writer
+    - command: my-plugin.my_writer
       filename_extensions: ["*.pcd", "*.e57"]
       layer_types: ["points{1}", "surface+"]
-    - command: my_plugin.my_single_writer
+    - command: my-plugin.my_single_writer
       filename_extensions: ["*.xyz"]
       layer_types: ["labels"]
 
   widgets:
-    - command: my_plugin.some_widget
+    - command: my-plugin.some_widget
       display_name: My Widget
-    - command: my_plugin.some_function_widget
+    - command: my-plugin.some_function_widget
       display_name: A Widget From a Function
       autogenerate: true
   menus:
     /napari/layer_context:
       - submenu: mysubmenu
-      - command: my_plugin.hello_world
+      - command: my-plugin.hello_world
     mysubmenu:
-      - command: my_plugin.another_command
-      - command: my_plugin.affinder
+      - command: my-plugin.another_command
+      - command: my-plugin.affinder
   submenus:
     - id: mysubmenu
       label: My SubMenu
@@ -88,7 +88,7 @@ contributions:
   sample_data:
     - display_name: Some Random Data (512 x 512)
       key: random_data
-      command: my_plugin.generate_random_data
+      command: my-plugin.generate_random_data
     - display_name: Random internet image
       key: internet_image
       uri: https://picsum.photos/1024

--- a/tests/test_contributions.py
+++ b/tests/test_contributions.py
@@ -6,6 +6,8 @@ import pytest
 from npe2 import PluginManager, PluginManifest
 from npe2.manifest.commands import CommandContribution
 
+SAMPLE_PLUGIN_NAME = "my-plugin"
+
 
 def test_writer_empty_layers():
     pm = PluginManager()
@@ -28,7 +30,7 @@ def test_writer_empty_layers():
 def test_writer_ranges(param, uses_sample_plugin, plugin_manager: PluginManager):
     layer_types, expected_count = param
     nwriters = sum(
-        w.command == "my_plugin.my_writer"
+        w.command == f"{SAMPLE_PLUGIN_NAME}.my_writer"
         for w in plugin_manager.iter_compatible_writers(layer_types)
     )
 
@@ -43,7 +45,7 @@ def test_writer_valid_layer_type_expressions(expr, uses_sample_plugin):
     result = next(
         result
         for result in PluginManifest.discover()
-        if result.manifest and result.manifest.name == "my_plugin"
+        if result.manifest and result.manifest.name == SAMPLE_PLUGIN_NAME
     )
     assert result.error is None
     assert result.manifest is not None
@@ -61,7 +63,7 @@ def test_writer_for_command(
     uses_sample_plugin, plugin_manager: PluginManager, tmp_path
 ):
     reader = list(plugin_manager.iter_compatible_readers(tmp_path))[0]
-    assert reader.command == "my_plugin.some_reader"
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 
 def test_widgets(uses_sample_plugin, plugin_manager: PluginManager):
@@ -69,24 +71,24 @@ def test_widgets(uses_sample_plugin, plugin_manager: PluginManager):
 
     widgets = list(plugin_manager.iter_widgets())
     assert len(widgets) == 2
-    assert widgets[0].command == "my_plugin.some_widget"
+    assert widgets[0].command == f"{SAMPLE_PLUGIN_NAME}.some_widget"
     w = widgets[0].exec()
     assert type(w).__name__ == "SomeWidget"
 
-    assert widgets[1].command == "my_plugin.some_function_widget"
+    assert widgets[1].command == f"{SAMPLE_PLUGIN_NAME}.some_function_widget"
     w = widgets[1].get_callable()
     assert isinstance(w, MagicFactory)
 
 
 def test_sample(uses_sample_plugin, plugin_manager: PluginManager):
     plugin, contribs = list(plugin_manager.iter_sample_data())[0]
-    assert plugin == "my_plugin"
+    assert plugin == SAMPLE_PLUGIN_NAME
     assert len(contribs) == 2
     ctrbA, ctrbB = contribs
     # ignoring types because .command and .uri come from different sample provider
     # types... they don't both have "command" or "uri"
-    assert ctrbA.command == "my_plugin.generate_random_data"
-    assert ctrbA.plugin_name == "my_plugin"
+    assert ctrbA.command == f"{SAMPLE_PLUGIN_NAME}.generate_random_data"
+    assert ctrbA.plugin_name == SAMPLE_PLUGIN_NAME
     assert ctrbB.uri == "https://picsum.photos/1024"
     assert isinstance(ctrbA.open(), list)
     assert isinstance(ctrbB.open(), list)
@@ -94,7 +96,7 @@ def test_sample(uses_sample_plugin, plugin_manager: PluginManager):
 
 def test_directory_reader(uses_sample_plugin, plugin_manager: PluginManager, tmp_path):
     reader = list(plugin_manager.iter_compatible_readers(tmp_path))[0]
-    assert reader.command == "my_plugin.some_reader"
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 
 def test_themes(uses_sample_plugin, plugin_manager: PluginManager):

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -3,6 +3,8 @@ import pytest
 from npe2.io_utils import read, read_get_reader, write, write_get_writer
 from npe2.types import FullLayerData
 
+SAMPLE_PLUGIN_NAME = "my-plugin"
+
 
 def test_read(uses_sample_plugin):
     assert read("some.fzzy") == [(None,)]
@@ -17,7 +19,7 @@ def test_read_with_plugin(uses_sample_plugin):
 def test_read_return_reader(uses_sample_plugin):
     data, reader = read_get_reader("some.fzzy")
     assert data == [(None,)]
-    assert reader.command == "my_plugin.some_reader"
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 
 null_image: FullLayerData = ([], {}, "image")
@@ -30,7 +32,7 @@ def test_writer_exec(uses_sample_plugin):
 
     result, contrib = write_get_writer("test.tif", [null_image, null_image])
     assert result == ["test.tif"]
-    assert contrib.command == "my_plugin.my_writer"
+    assert contrib.command == f"{SAMPLE_PLUGIN_NAME}.my_writer"
 
 
 @pytest.mark.parametrize("layer_data", [[null_image, null_image], []])

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -6,6 +6,8 @@ from npe2._command_registry import CommandHandler, CommandRegistry
 from npe2._plugin_manager import PluginManager
 from npe2.manifest.schema import PluginManifest
 
+SAMPLE_PLUGIN_NAME = "my-plugin"
+
 
 @pytest.fixture
 def pm(sample_path):
@@ -22,27 +24,27 @@ def pm(sample_path):
 
 
 def test_plugin_manager(pm: PluginManager):
-    assert pm.get_command("my_plugin.hello_world")
+    assert pm.get_command(f"{SAMPLE_PLUGIN_NAME}.hello_world")
 
-    assert "my_plugin" not in pm._contexts
-    ctx = pm.activate("my_plugin")
-    assert "my_plugin" in pm._contexts
-    assert pm.get_manifest("my_plugin")
+    assert SAMPLE_PLUGIN_NAME not in pm._contexts
+    ctx = pm.activate(SAMPLE_PLUGIN_NAME)
+    assert SAMPLE_PLUGIN_NAME in pm._contexts
+    assert pm.get_manifest(SAMPLE_PLUGIN_NAME)
 
     # dual activation is prevented
-    assert pm.activate("my_plugin") is ctx
+    assert pm.activate(SAMPLE_PLUGIN_NAME) is ctx
 
-    assert pm.get_command("my_plugin.hello_world")
+    assert pm.get_command(f"{SAMPLE_PLUGIN_NAME}.hello_world")
 
     assert pm.get_submenu("mysubmenu")
     assert len(list(pm.iter_menu("/napari/layer_context"))) == 2
 
     # deactivation
-    assert "my_plugin" in pm._contexts
-    pm.deactivate("my_plugin")
-    assert "my_plugin" not in pm._contexts
-    pm.deactivate("my_plugin")  # second time is a no-op
-    assert "my_plugin" not in pm._contexts
+    assert SAMPLE_PLUGIN_NAME in pm._contexts
+    pm.deactivate(SAMPLE_PLUGIN_NAME)
+    assert SAMPLE_PLUGIN_NAME not in pm._contexts
+    pm.deactivate(SAMPLE_PLUGIN_NAME)  # second time is a no-op
+    assert SAMPLE_PLUGIN_NAME not in pm._contexts
 
 
 def test_plugin_manager_raises(pm: PluginManager):
@@ -51,10 +53,10 @@ def test_plugin_manager_raises(pm: PluginManager):
     with pytest.raises(KeyError):
         pm.activate("not a thing")
     with pytest.raises(KeyError):
-        pm.get_command("my_plugin.not_a_thing")
+        pm.get_command(f"{SAMPLE_PLUGIN_NAME}.not_a_thing")
     with pytest.raises(ValueError) as e:
-        pm.register(PluginManifest(name="my_plugin"))
-    assert "A manifest with name 'my_plugin' already exists." in str(e.value)
+        pm.register(PluginManifest(name=SAMPLE_PLUGIN_NAME))
+    assert f"A manifest with name {SAMPLE_PLUGIN_NAME!r} already" in str(e.value)
 
 
 def test_command_handler():

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -8,6 +8,8 @@ from npe2.manifest import _validators
 
 # the docstrings here are used to assert the validation error that is printed.
 
+SAMPLE_PLUGIN_NAME = "my-plugin"
+
 
 def _mutator_invalid_package_name(data):
     """'invalid??' is not a valid python package name."""
@@ -20,7 +22,7 @@ def _mutator_invalid_package_name2(data):
 
 
 def _mutator_command_not_begin_with_package_name(data):
-    """Commands identifiers must start with the current package name 'my_plugin'"""
+    """Commands identifiers must start with the current package name"""
     assert "contributions" in data
     c = data["contributions"]["commands"][0]["id"]
     data["contributions"]["commands"][0]["id"] = ".".join(
@@ -92,7 +94,7 @@ def test_invalid(mutator, uses_sample_plugin):
     result = next(
         result
         for result in PluginManifest.discover()
-        if result.manifest and result.manifest.name == "my_plugin"
+        if result.manifest and result.manifest.name == SAMPLE_PLUGIN_NAME
     )
     assert result.error is None
     assert result.manifest is not None
@@ -187,7 +189,7 @@ def test_writer_invalid_layer_type_expressions(expr, uses_sample_plugin):
     result = next(
         result
         for result in PluginManifest.discover()
-        if result.manifest and result.manifest.name == "my_plugin"
+        if result.manifest and result.manifest.name == SAMPLE_PLUGIN_NAME
     )
     assert result.error is None
     assert result.manifest is not None


### PR DESCRIPTION
To avoid confusion between packages and modules, this changes the name of the sample plugin that we test to `my-plugin` from `my_plugin` (which is the top module)