### PR TITLE
Add option to validate python_name imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ ENV/
 # IDE settings
 .vscode/
 npe2/_version.py
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,3 @@ ENV/
 # IDE settings
 .vscode/
 npe2/_version.py
-docs/

--- a/npe2/_command_registry.py
+++ b/npe2/_command_registry.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from importlib import import_module
 from typing import Any, Callable, Dict, Optional, Union
 
 from psygnal import Signal
 
 from .manifest._validators import DOTTED_NAME_PATTERN
+from .manifest.utils import import_python_name
+from .types import PythonName
 
 PDisposable = Callable[[], None]
 
@@ -17,7 +18,7 @@ PDisposable = Callable[[], None]
 class CommandHandler:
     id: str
     function: Optional[Callable] = None
-    python_name: Optional[str] = None
+    python_name: Optional[PythonName] = None
 
     def resolve(self) -> Callable:
         if self.function is not None:
@@ -26,9 +27,7 @@ class CommandHandler:
             raise RuntimeError("cannot resolve command without python_name")
 
         try:
-            module_name, class_name = self.python_name.rsplit(":", 1)
-            module = import_module(module_name)
-            self.function = getattr(module, class_name)
+            self.function = import_python_name(self.python_name)
         except Exception as e:
             raise RuntimeError("Failed to import command at {self.python_name!r}: {e}")
         return self.function
@@ -77,7 +76,7 @@ class CommandRegistry:
                 raise ValueError(
                     "String command {command!r} is not a valid qualified python path."
                 )
-            cmd = CommandHandler(id, python_name=command)
+            cmd = CommandHandler(id, python_name=PythonName(command))
         elif not callable(command):
             raise TypeError(f"Cannot register non-callable command: {command}")
         else:

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -40,12 +40,13 @@ def validate(
     name: str,
     imports: bool = typer.Option(
         False,
-        help="Validate all python_name entries by importing",
+        help="Validate all `python_name` entries by importing. This runs python code! "
+        "package must be importable on sys.path.",
     ),
     debug: bool = typer.Option(
         False,
         "--debug",
-        help="Just print manifest to stdout. Do not modify anything",
+        help="Print tracebacks on error.",
     ),
 ):
     """Validate manifest for a distribution name or manifest filepath."""

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -38,7 +38,7 @@ def _pprint_exception(err: Exception):
 @app.command()
 def validate(
     name: str,
-    validate_imports: bool = typer.Option(
+    imports: bool = typer.Option(
         False,
         help="Validate all python_name entries by importing",
     ),
@@ -50,11 +50,11 @@ def validate(
 ):
     """Validate manifest for a distribution name or manifest filepath."""
 
-    err = None
+    err: Optional[Exception] = None
     try:
         pm = PluginManifest._from_package_or_name(name)
         msg = f"✔ Manifest for {(pm.display_name or pm.name)!r} valid!"
-        if validate_imports:
+        if imports:
             pm.validate_imports()
     except PluginManifest.ValidationError as e:
         msg = f"🅇 Invalid! {e}"

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -21,23 +21,54 @@ def _pprint_yaml(string):  # pragma: no cover
         typer.echo(string)
 
 
+def _pprint_exception(err: Exception):
+    e_info = (type(err), err, err.__traceback__)
+    try:
+        from rich.console import Console
+        from rich.traceback import Traceback
+
+        trace = Traceback.extract(*e_info, show_locals=True)
+        Console().print(Traceback(trace))
+    except ImportError:
+        import traceback
+
+        typer.echo("\n" + "".join(traceback.format_exception(*e_info)))
+
+
 @app.command()
-def validate(name: str, debug: bool = False):
+def validate(
+    name: str,
+    validate_imports: bool = typer.Option(
+        False,
+        help="Validate all python_name entries by importing",
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help="Just print manifest to stdout. Do not modify anything",
+    ),
+):
     """Validate manifest for a distribution name or manifest filepath."""
 
-    valid = False
+    err = None
     try:
         pm = PluginManifest._from_package_or_name(name)
         msg = f"✔ Manifest for {(pm.display_name or pm.name)!r} valid!"
-        valid = True
-    except PluginManifest.ValidationError as err:
-        msg = f"🅇 Invalid! {err}"
-    except Exception as err:
-        msg = f"🅇 Failed to load {name!r}. {type(err).__name__}: {err}"
-        if debug:
-            raise
+        if validate_imports:
+            pm.validate_imports()
+    except PluginManifest.ValidationError as e:
+        msg = f"🅇 Invalid! {e}"
+        err = e
+    except Exception as e:
+        msg = f"🅇 Unexpected error in {name!r}.\n{type(e).__name__}: {e}"
+        err = e
 
-    typer.secho(msg, fg=typer.colors.GREEN if valid else typer.colors.RED, bold=True)
+    typer.secho(msg, fg=typer.colors.RED if err else typer.colors.GREEN, bold=True)
+    if err is not None:
+        if debug:
+            _pprint_exception(err)
+
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/npe2/manifest/_bases.py
+++ b/npe2/manifest/_bases.py
@@ -78,7 +78,7 @@ class ImportExportModel(BaseModel):
         elif path.suffix.lower() in (".yaml", ".yml"):
             loader = yaml.safe_load
         else:
-            raise ValueError(f"unrecognized file extension: {path}")
+            raise ValueError(f"unrecognized file extension: {path}")  # pragma: no cover
 
         with open(path) as f:
             data = loader(f) or {}

--- a/npe2/manifest/commands.py
+++ b/npe2/manifest/commands.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, Extra, Field, validator
 
+from ..types import PythonName
 from . import _validators
 
 if TYPE_CHECKING:
@@ -74,7 +75,7 @@ class CommandContribution(BaseModel):
     #     ),
     # )
 
-    python_name: Optional[str] = Field(
+    python_name: Optional[PythonName] = Field(
         None,
         description="(Optional) Fully qualified name to callable python object "
         "implementing this command. This usually takes the form of "

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -342,7 +342,8 @@ class PluginManifest(ImportExportModel):
                     "package name or a file.."
                 ) from e
 
-    def validate_imports(self):
+    def validate_imports(self) -> None:
+        """Checks recursively that all `python_name` fields are actually importable."""
         from .utils import import_python_name
 
         errors = []

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -16,6 +16,8 @@ from typing import (
     Union,
 )
 
+from ..types import PythonName
+
 if TYPE_CHECKING:
     from typing_extensions import Protocol
 
@@ -147,3 +149,18 @@ class Version:
         if self.build:  # pragma: no cover
             v += str(self.build)
         return v
+
+
+def import_python_name(python_name: PythonName) -> object:
+    from importlib import import_module
+
+    from ._validators import PYTHON_NAME_PATTERN
+
+    match = PYTHON_NAME_PATTERN.match(python_name)
+    if not match:  # pragma: no cover
+        raise ValueError(f"Invalid python name: {python_name}")
+
+    module_name, funcname = match.groups()
+
+    mod = import_module(module_name)
+    return getattr(mod, funcname)

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -151,7 +151,7 @@ class Version:
         return v
 
 
-def import_python_name(python_name: PythonName) -> object:
+def import_python_name(python_name: PythonName) -> Any:
     from importlib import import_module
 
     from ._validators import PYTHON_NAME_PATTERN

--- a/npe2/types.py
+++ b/npe2/types.py
@@ -1,5 +1,15 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    NewType,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from typing_extensions import Literal, Protocol
 
@@ -13,7 +23,7 @@ if TYPE_CHECKING:
 
 PathLike = Union[str, Path]
 PathOrPaths = Union[PathLike, Sequence[PathLike]]
-
+PythonName = NewType("PythonName", str)
 
 # Layer-related types
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ dev =
     pydocstyle
     pytest
     pytest-cov
+    rich
     typer
 testing =
     magicgui
@@ -65,6 +66,7 @@ testing =
     numpy
     pytest
     pytest-cov
+    rich
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ runner = CliRunner()
 
 
 @pytest.mark.parametrize("debug", ["--debug", ""])
-@pytest.mark.parametrize("imports", ["--validate-imports", "--no-validate-imports"])
+@pytest.mark.parametrize("imports", ["--imports", "--no-imports"])
 def test_cli_validate_ok(sample_path, debug, imports, monkeypatch):
     cmd = ["validate", str(sample_path / "my_plugin" / "napari.yaml"), imports]
     if debug:
@@ -17,8 +17,8 @@ def test_cli_validate_ok(sample_path, debug, imports, monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(sys, "path", sys.path + [str(sample_path)])
         result = runner.invoke(app, cmd)
-    assert result.exit_code == 0
     assert "✔ Manifest for 'My Plugin' valid!" in result.stdout
+    assert result.exit_code == 0
 
 
 def test_cli_validate_invalid(tmp_path, capsys):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -5,6 +5,7 @@ import pytest
 from npe2._command_registry import CommandHandler, CommandRegistry
 from npe2._plugin_manager import PluginManager
 from npe2.manifest.schema import PluginManifest
+from npe2.types import PythonName
 
 SAMPLE_PLUGIN_NAME = "my-plugin"
 
@@ -66,7 +67,7 @@ def test_command_handler():
 
     with pytest.raises(RuntimeError):
         # cannot resolve something without either a python_name or function
-        CommandHandler("hi", python_name="cannot.import.this").resolve()
+        CommandHandler("hi", python_name=PythonName("cannot.import.this")).resolve()
 
 
 def test_command_reg_register():

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -116,9 +116,10 @@ def test_invalid_python_name(uses_sample_plugin):
     assert mf.contributions.commands[-1].python_name
 
     assert mf.validate_imports() is None
-    mf.contributions.commands[-1].python_name += "whoops"  # type: ignore
-    with pytest.raises(ValidationError):
+    mf.contributions.commands[-1].python_name += "_whoops"  # type: ignore
+    with pytest.raises(ValidationError) as e:
         mf.validate_imports()
+    assert "has no attribute 'make_widget_from_function_whoops'" in str(e.value)
 
 
 def _valid_mutator_no_contributions(data):

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -106,6 +106,21 @@ def test_invalid(mutator, uses_sample_plugin):
     assert mutator.__doc__ in str(excinfo.value)
 
 
+def test_invalid_python_name(uses_sample_plugin):
+    mf = next(
+        result
+        for result in PluginManifest.discover()
+        if result.manifest and result.manifest.name == SAMPLE_PLUGIN_NAME
+    ).manifest
+    assert mf and mf.contributions and mf.contributions.commands
+    assert mf.contributions.commands[-1].python_name
+
+    assert mf.validate_imports() is None
+    mf.contributions.commands[-1].python_name += "whoops"  # type: ignore
+    with pytest.raises(ValidationError):
+        mf.validate_imports()
+
+
 def _valid_mutator_no_contributions(data):
     """
     Contributions can be absent, in which case the Pydantic model will set the


### PR DESCRIPTION
as mentioned/requested by @jni in the conversation in #75 

This adds a method `PluginManifest.validate_imports` and a new flag to the cli `npe2 validate --imports` that checks to see that all of the `python_names` used in the manifest are importable

this also has the very nice side effect of making `npe2.manifest.utils.import_python_name` the _only_ place in the code where we import things from packages