### PR TITLE
Handle list of paths in iter_compatible_reader

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -206,7 +206,7 @@ class PluginManager:
 
         is_directory = False
         if not isinstance(paths, list):
-            path = str(paths)
+            path = str(paths)  # needed in order to pass pre-commit hook
             if os.path.isdir(path):
                 # This is a directory.  Get a list of all files in the directory.
                 is_directory = True
@@ -222,7 +222,7 @@ class PluginManager:
 
             path = paths[0]
         else:
-            path = str(paths)
+            path = str(paths)  # needed in order to pass pre-commit hook
         seen: Set[str] = set()
         for ext, readers in self._contrib._readers.items():
             if ext and fnmatch(str(path), ext):

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -211,7 +211,7 @@ class PluginManager:
 
             path = paths[0]
         else:
-            path = paths  # needed in order to pass pre-commit hook
+            path = paths
 
         if os.path.isdir(path):
             yield from self._contrib._readers[""]

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-__all__ = ["PluginContext", "PluginManager"]
-
 import os
 from collections import Counter
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -27,7 +26,7 @@ from intervaltree import IntervalTree
 from ._command_registry import CommandRegistry
 from .manifest import PluginManifest
 from .manifest.writers import LayerType, WriterContribution
-from .types import PythonName
+from .types import PathLike, PythonName
 
 if TYPE_CHECKING:
     from .manifest.commands import CommandContribution
@@ -54,6 +53,7 @@ if TYPE_CHECKING:
             ...
 
 
+__all__ = ["PluginContext", "PluginManager"]
 PluginName = str  # this is `PluginManifest.name`
 
 
@@ -200,18 +200,17 @@ class PluginManager:
         ctx._dispose()
 
     def iter_compatible_readers(
-        self, paths: Union[str, Path, Sequence[Union[str, Path]]]
+        self, path: Union[PathLike, List[PathLike]]
     ) -> Iterator[ReaderContribution]:
-        from fnmatch import fnmatch
+        if not path:
+            return
 
-        if isinstance(paths, list) and len(paths):
-            assert all(
-                [idx.endswith(paths[0].split(".")[-1]) is True for idx in paths]
-            ), "All paths in the stack list must have the same extension."
-
-            path = paths[0]
-        else:
-            path = paths
+        if isinstance(path, list):
+            if len({Path(i).suffix for i in path}) > 1:
+                raise ValueError(
+                    "All paths in the stack list must have the same extension."
+                )
+            path = path[0]
 
         if os.path.isdir(path):
             yield from self._contrib._readers[""]

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -204,7 +204,7 @@ class PluginManager:
     ) -> Iterator[ReaderContribution]:
         from fnmatch import fnmatch
 
-        if isinstance(paths, list) and len(paths) > 1:
+        if isinstance(paths, list) and len(paths):
             assert all(
                 [idx.endswith(paths[0].split(".")[-1]) is True for idx in paths]
             ), "All paths in the stack list must have the same extension."

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -200,20 +200,9 @@ class PluginManager:
         ctx._dispose()
 
     def iter_compatible_readers(
-        self, paths: Sequence[Union[str, Path]]
+        self, paths: Union[str, Path, Sequence[Union[str, Path]]]
     ) -> Iterator[ReaderContribution]:
         from fnmatch import fnmatch
-
-        is_directory = False
-        if not isinstance(paths, list):
-            path = str(paths)  # needed in order to pass pre-commit hook
-            if os.path.isdir(path):
-                # This is a directory.  Get a list of all files in the directory.
-                is_directory = True
-                pathNames = list()
-                for (dirpath, dirnames, files) in os.walk(path):
-                    pathNames += [os.path.join(dirpath, file) for file in files]
-                paths = pathNames
 
         if isinstance(paths, list) and len(paths) > 1:
             assert all(
@@ -222,18 +211,18 @@ class PluginManager:
 
             path = paths[0]
         else:
-            path = str(paths)  # needed in order to pass pre-commit hook
-        seen: Set[str] = set()
-        for ext, readers in self._contrib._readers.items():
-            if ext and fnmatch(str(path), ext):
-                for r in readers:
-                    if is_directory and not r.accepts_directories:
-                        # if this reader does not accept a directory and
-                        # this is a directory then skip it.
-                        continue
-                    if r.command not in seen:
-                        seen.add(r.command)
-                        yield r
+            path = paths  # needed in order to pass pre-commit hook
+
+        if os.path.isdir(path):
+            yield from self._contrib._readers[""]
+        else:
+            seen: Set[str] = set()
+            for ext, readers in self._contrib._readers.items():
+                if ext and fnmatch(str(path), ext):
+                    for r in readers:
+                        if r.command not in seen:
+                            seen.add(r.command)
+                            yield r
 
     @classmethod
     def instance(cls) -> PluginManager:

--- a/tests/test_contributions.py
+++ b/tests/test_contributions.py
@@ -59,11 +59,16 @@ def test_writer_valid_layer_type_expressions(expr, uses_sample_plugin):
     PluginManifest(**data)
 
 
-def test_writer_for_command(
-    uses_sample_plugin, plugin_manager: PluginManager, tmp_path
-):
+def test_basic_iter_reader(uses_sample_plugin, plugin_manager: PluginManager, tmp_path):
+    assert list(plugin_manager.iter_compatible_readers("")) == []
     reader = list(plugin_manager.iter_compatible_readers(tmp_path))[0]
     assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+    reader = list(plugin_manager.iter_compatible_readers([tmp_path, tmp_path]))[0]
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+    with pytest.raises(ValueError):
+        list(plugin_manager.iter_compatible_readers(["a.tif", "b.jpg"]))
 
 
 def test_widgets(uses_sample_plugin, plugin_manager: PluginManager):


### PR DESCRIPTION
I made some changes to `iter_compatible_readers` in order to accept a list of paths.  This will now open stacks.  <s>Also,  npe2 was not being used for folders, and I made a change to handle those as well.</s>. I see that it did handle folders, I realized it was not using the npe2 reader I was testing with to read.  

Fixes #81 .