### PR TITLE
set display_name to plugin name when empty

### DIFF
--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -176,6 +176,9 @@ class PluginManifest(ImportExportModel):
                 )
             )
 
+        if not values.get("display_name"):
+            values["display_name"] = mf_name
+
         return values
 
     @classmethod


### PR DESCRIPTION
By default `display_name` is the empty string. Client code has to coerce that to something reasonable (See napari/napari#4039).

It's a lot cleaner if we just do it here. This PR adds a rule to the `PluginManifest` root validator.

