### PR TITLE
Make conversion robust to entry_point string entries

### DIFF
--- a/npe2/_from_npe1.py
+++ b/npe2/_from_npe1.py
@@ -565,6 +565,8 @@ class _SetupVisitor(ast.NodeVisitor):
                 eps: dict = ast.literal_eval(kw.value)
                 for k, v in eps.items():
                     if k == NPE1_EP:
+                        if type(v) is str:
+                            v = [v]
                         for item in v:
                             self._entry_points.append(
                                 [i.strip() for i in item.split("=")]

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -78,6 +78,24 @@ setup(
     assert "npe1-plugin = npe1_module:napari.yaml" in str(msg)
 
 
+def test_conversion_entry_point_string(npe1_repo, mock_npe1_pm_with_plugin):
+    (npe1_repo / "setup.cfg").unlink()
+    (npe1_repo / "setup.py").write_text(
+        """from setuptools import setup
+
+setup(
+    name='npe1-plugin',
+    entry_points={"napari.plugin": "npe1-plugin = npe1_module"}
+)
+"""
+    )
+    with pytest.warns(UserWarning) as record:
+        convert_repository(npe1_repo)
+    msg = record[0].message
+    assert "Cannot auto-update setup.py, please edit setup.py as follows" in str(msg)
+    assert "npe1-plugin = npe1_module:napari.yaml" in str(msg)
+
+
 def test_conversion_missing():
     with pytest.raises(ModuleNotFoundError), pytest.warns(UserWarning):
         manifest_from_npe1("does-not-exist-asdf6as987")


### PR DESCRIPTION
Closes #93 

Adds some logic to handle `entry_point`'s specified as a string rather than a list.

Added a test. The test was done for `setup.py` conversions since it's a little harder to make the mistake in the `cfg` format.
