### PR TITLE
add min_ver to PackageMetadata

### DIFF
--- a/npe2/__init__.py
+++ b/npe2/__init__.py
@@ -8,11 +8,13 @@ __email__ = "talley.lambert@gmail.com"
 from ._plugin_manager import PluginContext, PluginManager
 from .io_utils import read, write
 from .manifest import PluginManifest
+from .manifest.package_metadata import PackageMetadata
 
 __all__ = [
     "PluginManifest",
     "PluginManager",
     "PluginContext",
+    "PackageMetadata",
     "write",
     "read",
 ]

--- a/npe2/manifest/package_metadata.py
+++ b/npe2/manifest/package_metadata.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Extra, Field, constr
+from pydantic import BaseModel, Extra, Field, constr, root_validator
 from pydantic.fields import SHAPE_LIST
 from typing_extensions import Literal
 
@@ -33,7 +33,9 @@ class PackageMetadata(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    metadata_version: MetadataVersion = Field(description="Version of the file format")
+    metadata_version: MetadataVersion = Field(
+        "1.0", description="Version of the file format"
+    )
     name: PackageName = Field(  # type: ignore
         ...,
         description="The name of the distribution. The name field "
@@ -44,13 +46,14 @@ class PackageMetadata(BaseModel):
     # but it will fail on some dev versions, and it's not worth it.
     version: str = Field(
         ...,
-        description="A string containing the distribution’s version number. "
+        description="A string containing the distribution's version number. "
         "This field must be in the format specified in PEP 440.",
     )
     dynamic: Optional[List[str]] = Field(
         None,
         description="A string containing the name of another core metadata "
         "field. The field names Name and Version may not be specified in this field.",
+        min_ver="2.2",
     )
     platform: Optional[List[str]] = Field(
         None,
@@ -63,6 +66,7 @@ class PackageMetadata(BaseModel):
         description="Binary distributions containing a PKG-INFO file will use the "
         "Supported-Platform field in their metadata to specify the OS and CPU for "
         "which the binary distribution was compiled",
+        min_ver="1.1",
     )
     summary: Optional[str] = Field(
         None, description="A one-line summary of what the distribution does."
@@ -75,8 +79,10 @@ class PackageMetadata(BaseModel):
     description_content_type: Optional[str] = Field(
         None,
         description="A string stating the markup syntax (if any) used in the "
-        "distribution’s description, so that tools can intelligently render the "
-        "description.",
+        "distribution's description, so that tools can intelligently render the "
+        "description. The type/subtype part has only a few legal values: "
+        "text/plain, text/x-rst, text/markdown",
+        min_ver="2.1",
     )
     keywords: Optional[str] = Field(
         None,
@@ -85,33 +91,36 @@ class PackageMetadata(BaseModel):
     )
     home_page: Optional[str] = Field(
         None,
-        description="A string containing the URL for the distribution’s home page.",
+        description="A string containing the URL for the distribution's home page.",
     )
     download_url: Optional[str] = Field(
         None,
         description="A string containing the URL from which THIS version of the "
         "distribution can be downloaded.",
+        min_ver="1.1",
     )
     author: Optional[str] = Field(
         None,
-        description="A string containing the author’s name at a minimum; "
+        description="A string containing the author's name at a minimum; "
         "additional contact information may be provided.",
     )
     author_email: Optional[str] = Field(
         None,
-        description="A string containing the author’s e-mail address. It can contain "
+        description="A string containing the author's e-mail address. It can contain "
         "a name and e-mail address in the legal forms for a RFC-822 From: header.",
     )
     maintainer: Optional[str] = Field(
         None,
-        description="A string containing the maintainer’s name at a minimum; "
+        description="A string containing the maintainer's name at a minimum; "
         "additional contact information may be provided.",
+        min_ver="1.2",
     )
     maintainer_email: Optional[str] = Field(
         None,
-        description="A string containing the maintainer’s e-mail address. It can "
+        description="A string containing the maintainer's e-mail address. It can "
         "contain a name and e-mail address in the legal forms for a "
         "RFC-822 From: header.",
+        min_ver="1.2",
     )
     license: Optional[str] = Field(
         None,
@@ -126,12 +135,14 @@ class PackageMetadata(BaseModel):
         description="Each entry is a string giving a single classification value for "
         "the distribution. Classifiers are described in PEP 301, and the Python "
         "Package Index publishes a dynamic list of currently defined classifiers.",
+        min_ver="1.1",
     )
     requires_dist: Optional[List[str]] = Field(
         None,
         description="The field format specification was relaxed to accept the syntax "
         "used by popular publishing tools. Each entry contains a string naming some "
         "other distutils project required by this distribution.",
+        min_ver="1.2",
     )
     requires_python: Optional[str] = Field(
         None,
@@ -139,6 +150,7 @@ class PackageMetadata(BaseModel):
         "is guaranteed to be compatible with. Installation tools may look at this "
         "when picking which version of a project to install. "
         "The value must be in the format specified in Version specifiers (PEP 440).",
+        min_ver="1.2",
     )
     requires_external: Optional[List[str]] = Field(
         None,
@@ -147,22 +159,33 @@ class PackageMetadata(BaseModel):
         "some dependency in the system that the distribution is to be used. This "
         "field is intended to serve as a hint to downstream project maintainers, and "
         "has no semantics which are meaningful to the distutils distribution.",
+        min_ver="1.2",
     )
     project_url: Optional[List[str]] = Field(
         None,
         description="A string containing a browsable URL for the project and a label "
         "for it, separated by a comma.",
+        min_ver="1.2",
     )
     provides_extra: Optional[List[str]] = Field(
         None,
         description="A string containing the name of an optional feature. Must be a "
         "valid Python identifier. May be used to make a dependency conditional on "
         "whether the optional feature has been requested.",
+        min_ver="2.1",
     )
 
     # rarely_used
-    provides_dist: Optional[List[str]] = None
-    obsoletes_dist: Optional[List[str]] = None
+    provides_dist: Optional[List[str]] = Field(None, min_ver="1.2")
+    obsoletes_dist: Optional[List[str]] = Field(None, min_ver="1.2")
+
+    @root_validator(pre=True)
+    def _validate_root(cls, values):
+        if "metadata_version" not in values:
+            fields = cls.__fields__
+            mins = {fields[n].field_info.extra.get("min_ver", "1.0") for n in values}
+            values["metadata_version"] = str(max(float(x) for x in mins))
+        return values
 
     @classmethod
     def for_package(cls, name: str) -> "PackageMetadata":

--- a/tests/test_package_meta.py
+++ b/tests/test_package_meta.py
@@ -1,0 +1,15 @@
+from npe2 import PackageMetadata
+
+
+def test_package_metadata_version():
+    """Test that we intelligently pick the min required metadata version"""
+    assert PackageMetadata(name="test", version="1.0").metadata_version == "1.0"
+    pm2 = PackageMetadata(name="test", version="1.0", maintainer="bob")
+    assert pm2.metadata_version == "1.2"
+    pm3 = PackageMetadata(
+        name="test",
+        version="1.0",
+        maintainer="bob",
+        description_content_type="text/markdown",
+    )
+    assert pm3.metadata_version == "2.1"


### PR DESCRIPTION
If omitted, this will pick the min required metadata_version for PackageMetadata based on the fields used:

```py
pm = PackageMetadata(name="test", version="1.0", maintainer="bob")
assert pm.metadata_version == "1.2"  # because `maintainer` was introduced in 1.2
```