### PR TITLE
Add enable disable

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -188,10 +188,10 @@ class PluginManagerEvents(SignalGroup):
     activation_changed = Signal(
         set,
         set,
-        description="Emitted with two arguments: a set names of plugins "
-        "(strings) that were activated, and a set of names that were "
-        "deactivate. 'Activated' means the plugin has been *imported*, it's "
-        "`on_activate` function called.",
+        description="Emitted with two arguments: a set of plugin "
+        "names that were activated, and a set of names that were "
+        "deactivated. 'Activated' means the plugin has been *imported*, it's "
+        "`on_activate` function was called.",
     )
     enablement_changed = Signal(
         set,

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -190,7 +190,7 @@ class PluginManagerEvents(SignalGroup):
         set,
         description="Emitted with two arguments: a set of plugin "
         "names that were activated, and a set of names that were "
-        "deactivated. 'Activated' means the plugin has been *imported*, it's "
+        "deactivated. 'Activated' means the plugin has been *imported*, its "
         "`on_activate` function was called.",
     )
     enablement_changed = Signal(

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -363,12 +363,11 @@ class PluginManager:
 
     def iter_manifests(self, enabled=None) -> Iterator[PluginManifest]:
         for key, mf in self._manifests.items():
-            if enabled is True and self.is_disabled(mf.name):
+            if enabled is True and self.is_disabled(key):
                 continue
-            elif enabled is False and not self.is_disabled(mf.name):
+            elif enabled is False and not self.is_disabled(key):
                 continue
-            if not self.is_disabled(key):
-                yield mf
+            yield mf
 
     def __contains__(self, name: str) -> bool:
         return name in self._manifests

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -73,7 +73,7 @@ class _ContributionsIndex:
     def index_contributions(self, manifest: PluginManifest):
         ctrb = manifest.contributions
         if not ctrb or manifest.name in self._indexed:
-            return
+            return  # pragma: no cover
 
         self._indexed.add(manifest.name)
         for cmd in ctrb.commands or ():
@@ -90,7 +90,7 @@ class _ContributionsIndex:
     def remove_contributions(self, key: PluginName) -> None:
         """This must completely remove everything added by `index_contributions`."""
         if key not in self._indexed:
-            return
+            return  # pragma: no cover
 
         for cmd_id, (_, plugin) in list(self._commands.items()):
             if key == plugin:
@@ -199,7 +199,6 @@ class PluginManager:
         self._contexts: Dict[PluginName, PluginContext] = {}
         self._contrib = _ContributionsIndex()
         self._manifests: Dict[PluginName, PluginManifest] = {}
-        # self.discover()  # TODO: should we be immediately discovering?
 
     @property
     def commands(self) -> CommandRegistry:
@@ -210,8 +209,12 @@ class PluginManager:
 
         Parameters
         ----------
-        paths : Sequence[str], optional
+        paths : Sequence[str]
             Optional list of strings to insert at front of sys.path when discovering.
+        clear : bool
+            Clear and re-index the environment.  If `False` (the default), calling
+            discover again will only register and index newly discovered plugins.
+            (Existing manifests will not be re-indexed)
         """
         if clear:
             self._contrib = _ContributionsIndex()
@@ -223,6 +226,7 @@ class PluginManager:
                     self.register(result.manifest)
 
     def register(self, manifest: PluginManifest) -> None:
+        """Register a plugin manifest"""
         if manifest.name in self._manifests:
             raise ValueError(f"A manifest with name {manifest.name!r} already exists.")
 
@@ -312,7 +316,7 @@ class PluginManager:
     def enable(self, key: PluginName) -> None:
         """Enable a plugin"""
         if key not in self._disabled_plugins:
-            return
+            return  # pragma: no cover
 
         self._disabled_plugins.remove(key)
         mf = self._manifests.get(key)

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -196,8 +196,8 @@ class PluginManagerEvents(SignalGroup):
     enablement_changed = Signal(
         set,
         set,
-        description="Emitted with two arguments: a set names of plugins "
-        "(strings) that were enabled, and a set of names that were "
+        description="Emitted with two arguments: a set of plugin names "
+        "that were enabled, and a set of names that were "
         "disabled. 'Disabled' means the plugin remains installed, but it "
         "cannot be activated, and its contributions will not be indexed.",
     )

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -129,7 +129,7 @@ class PluginManifest(ImportExportModel):
     )
 
     def __hash__(self):
-        return hash(self.name) + hash(self.package_version)
+        return hash((self.name,self.package_version))
 
     @property
     def license(self) -> Optional[str]:

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -113,8 +113,8 @@ class PluginManifest(ImportExportModel):
         _validators.python_name
     )
 
-    contributions: Optional[ContributionPoints] = Field(
-        None,
+    contributions: ContributionPoints = Field(
+        default_factory=ContributionPoints,
         description="An object describing the plugin's "
         "[contributions](./contributions)",
     )
@@ -146,6 +146,10 @@ class PluginManifest(ImportExportModel):
     @property
     def author(self) -> Optional[str]:
         return self.package_metadata.author if self.package_metadata else None
+
+    @validator("contributions", pre=True)
+    def _coerce_none_contributions(cls, value):
+        return [] if value is None else value
 
     @root_validator
     def _validate_root(cls, values: dict) -> dict:

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -128,6 +128,9 @@ class PluginManifest(ImportExportModel):
         hide_docs=True,
     )
 
+    def __hash__(self):
+        return hash(self.name) + hash(self.package_version)
+
     @property
     def license(self) -> Optional[str]:
         return self.package_metadata.license if self.package_metadata else None

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -129,7 +129,7 @@ class PluginManifest(ImportExportModel):
     )
 
     def __hash__(self):
-        return hash((self.name,self.package_version))
+        return hash((self.name, self.package_version))
 
     @property
     def license(self) -> Optional[str]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     intervaltree
     magicgui>=0.3.3
     napari-plugin-engine
-    psygnal
+    psygnal>=0.3.0
     pydantic
     pytomlpp
     typer

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -71,8 +71,8 @@ contributions:
     - id: mysubmenu
       label: My SubMenu
   themes:
-    - label: "Monokai"
-      id: "monokai"
+    - label: "SampleTheme"
+      id: "sample_theme"
       type: "dark"
       colors:
         canvas: "#000000"

--- a/tests/test_contributions.py
+++ b/tests/test_contributions.py
@@ -72,48 +72,6 @@ def test_basic_iter_reader(uses_sample_plugin, plugin_manager: PluginManager, tm
         list(plugin_manager.iter_compatible_readers(["a.tif", "b.jpg"]))
 
 
-def test_disable_enable(uses_sample_plugin, plugin_manager: PluginManager, tmp_path):
-    def _assert_enabled():
-        # command
-        assert plugin_manager.get_command(f"{SAMPLE_PLUGIN_NAME}.hello_world")
-        # reader
-        cmds = [r.command for r in plugin_manager.iter_compatible_readers(tmp_path)]
-        assert f"{SAMPLE_PLUGIN_NAME}.some_reader" in cmds
-        # writer
-        cmds = [
-            r.command for r in plugin_manager.iter_compatible_writers(["image"] * 2)
-        ]
-        assert f"{SAMPLE_PLUGIN_NAME}.my_writer" in cmds
-
-        assert SAMPLE_PLUGIN_NAME in plugin_manager._contrib._indexed
-
-    _assert_enabled()
-
-    # Do disable
-    mock = Mock()
-    plugin_manager.enablement_changed.connect(mock)
-    plugin_manager.disable(SAMPLE_PLUGIN_NAME)
-    mock.assert_called_once_with({}, {SAMPLE_PLUGIN_NAME})  # enabled, disabled
-
-    assert SAMPLE_PLUGIN_NAME not in plugin_manager._contrib._indexed
-
-    # command
-    with pytest.raises(KeyError):
-        plugin_manager.get_command(f"{SAMPLE_PLUGIN_NAME}.hello_world")
-    # reader
-    cmds = [r.command for r in plugin_manager.iter_compatible_readers(tmp_path)]
-    assert f"{SAMPLE_PLUGIN_NAME}.some_reader" not in cmds
-    # writer
-    cmds = [r.command for r in plugin_manager.iter_compatible_writers(["image"] * 2)]
-    assert f"{SAMPLE_PLUGIN_NAME}.my_writer" not in cmds
-
-    # re-enable
-    mock.reset_mock()
-    plugin_manager.enable(SAMPLE_PLUGIN_NAME)
-    mock.assert_called_once_with({SAMPLE_PLUGIN_NAME}, {})  # enabled, disabled
-    _assert_enabled()
-
-
 def test_widgets(uses_sample_plugin, plugin_manager: PluginManager):
     from magicgui._magicgui import MagicFactory
 
@@ -151,7 +109,7 @@ def test_directory_reader(uses_sample_plugin, plugin_manager: PluginManager, tmp
 
 def test_themes(uses_sample_plugin, plugin_manager: PluginManager):
     theme = list(plugin_manager.iter_themes())[0]
-    assert theme.label == "Monokai"
+    assert theme.label == "SampleTheme"
 
 
 def test_command_exec():

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -170,3 +170,12 @@ def test_enable_disable(uses_sample_plugin, plugin_manager: PluginManager, tmp_p
     plugin_manager.enable(SAMPLE_PLUGIN_NAME)
     mock.assert_called_once_with({SAMPLE_PLUGIN_NAME}, {})  # enabled, disabled
     _assert_sample_enabled(plugin_manager)
+
+
+def test_warn_on_register_disabled(uses_sample_plugin, plugin_manager: PluginManager):
+    assert SAMPLE_PLUGIN_NAME in plugin_manager
+    mf = plugin_manager[SAMPLE_PLUGIN_NAME]
+    plugin_manager.disable(SAMPLE_PLUGIN_NAME)
+    plugin_manager._manifests.pop(SAMPLE_PLUGIN_NAME)  # NOT good way to "unregister"
+    with pytest.warns(UserWarning):
+        plugin_manager.register(mf)

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -152,6 +152,9 @@ def _assert_sample_enabled(plugin_manager: PluginManager, enabled=True):
 def test_enable_disable(uses_sample_plugin, plugin_manager: PluginManager, tmp_path):
 
     _assert_sample_enabled(plugin_manager)
+    # just to test the enabled= kwarg on iter_manifests
+    # (this would show *only* disabled plugins)
+    assert not list(plugin_manager.iter_manifests(disabled=True))
 
     # Do disable
     mock = Mock()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,4 +1,5 @@
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -22,6 +23,19 @@ def pm(sample_path):
         yield pm
     finally:
         sys.path.remove(str(sample_path))
+
+
+def test_discover_clear(uses_sample_plugin):
+    pm = PluginManager.instance()
+    assert SAMPLE_PLUGIN_NAME in pm._manifests
+
+    with patch.object(pm, "register") as mock:
+        pm.discover()
+        mock.assert_not_called()  # nothing new to register
+
+        mock.reset_mock()
+        pm.discover(clear=True)  # clear forces reregister
+        mock.assert_called_once()
 
 
 def test_plugin_manager(pm: PluginManager):

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -115,7 +115,7 @@ def test_invalid_python_name(uses_sample_plugin):
     assert mf and mf.contributions and mf.contributions.commands
     assert mf.contributions.commands[-1].python_name
 
-    assert mf.validate_imports() is None
+    mf.validate_imports()
     mf.contributions.commands[-1].python_name += "_whoops"  # type: ignore
     with pytest.raises(ValidationError) as e:
         mf.validate_imports()
@@ -125,16 +125,27 @@ def test_invalid_python_name(uses_sample_plugin):
 def _valid_mutator_no_contributions(data):
     """
     Contributions can be absent, in which case the Pydantic model will set the
-    default value to None, and not the empty list, make sure that works.
+    default value to an empty Contributions model
     """
     del data["contributions"]
 
 
+def _valid_mutator_no_contributions_empty(data):
+    """
+    Contributions can be an empty list, in which case the Pydantic model will set the
+    default value to an empty Contributions model
+    """
+    data["contributions"] = []
+
+
 def _valid_mutator_no_contributions_None(data):
     """
-    Contributions can be absent, in which case the Pydantic model will set the
+    Contributions can be None, in which case the Pydantic model will set the
     default value to None, and not the empty list, make sure that works.
     """
+    # This is no longer recommended.  A missing contributions is fine, and an empty
+    # list is fine.  We preserve this for backwards compatibility,
+    # but providing None explicitly shouldn't be used
     data["contributions"] = None
 
 


### PR DESCRIPTION
This adds:
- `PluginManager.enable`
- `PluginManager.disable`

and new signals:
- `PluginManager.events.plugins_registered`
- `PluginManager.events.activation_changed`
- `PluginManager.events.enablement_changed`

`_ContributionsIndex` has been minimized, but not completely removed, and gains a `remove_contributions` method

**ALSO**: note that this removes `discover()` from the init method.  So it must be called manually

see also https://github.com/napari/napari/pull/4086

I'm also taking the opportunity to re-order the methods and add docstrings on PluginManager (so the number of lines in this PR looks higher than it really is).  They're starting to get scattered about without much logic