### PR TITLE
Suggest to run npe2 validate when errors present.

### DIFF
--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -267,7 +267,13 @@ class PluginManifest(ImportExportModel):
                         pm = cls._from_entrypoint(ep, dist)
                         yield DiscoverResults(pm, ep, None)
                     except ValidationError as e:
-                        logger.warning(msg=f"Invalid schema {ep.value!r}")
+                        module_name, filename = ep.value.split(":")
+                        logger.warning(
+                            "Invalid schema for package %r, please run"
+                            " 'npe2 validate %s' to check for manifest errors.",
+                            module_name,
+                            module_name,
+                        )
                         yield DiscoverResults(None, ep, e)
                     except Exception as e:
                         logger.error(


### PR DESCRIPTION
See #100 I'm unsure if the logs message is enough or if it should pop up
a qt window.