### PR TITLE
Simplify Reader/writer internal logic.

### DIFF
--- a/_docs/render.py
+++ b/_docs/render.py
@@ -183,6 +183,8 @@ def main(dest: Path = _BUILD):
 
     dest.mkdir(exist_ok=True, parents=True)
     schema = PluginManifest.schema()
+    # this does not work offline.
+    # it should also likely not rely on latest release, should it ?
     with urlopen(SCHEMA_URL) as response:
         schema = json.load(response)
 

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -135,9 +135,8 @@ class _ContributionsIndex:
                 if l == lt and (min_ <= counts[lt] < max_)
             }
 
-        types = iter(LayerType)
-        candidates = _get_candidates(next(types))
-        for lt in types:
+        candidates = {w for _,_,_,w in self._writers}
+        for lt in LayerType:
             if candidates:
                 candidates &= _get_candidates(lt)
             else:

--- a/npe2/manifest/readers.py
+++ b/npe2/manifest/readers.py
@@ -30,3 +30,6 @@ class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
 
     class Config:
         extra = Extra.forbid
+
+    def __hash__(self):
+        return hash((self.command, tuple(self.filename_patterns), self.accepts_directories))

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ project_urls =
 packages = find:
 install_requires =
     PyYAML
-    intervaltree
     magicgui>=0.3.3
     napari-plugin-engine
     psygnal>=0.3.0


### PR DESCRIPTION
Sorry, in a train, tethering, a couple of comments inline. 

This is better read as 3 independant commits with each descriptions inlined below. 

Will come back to it and edit, but wanted to push it here to give you something to read :-) 
---- 


Simplify reader manipulation.

Migrate from a dict of list with complex mutations, with a flatter table
that we completely filter everytime.

Even with a few thousand readers this should still be quite fast and
simplify the code a bit. (Boring is good). We also make the reader
hashable even if technically the filename patterns are mutable (maybe
they should not be?) to simplify manipulation a bit more.

----  

Simplify writers: remove interval tree.

Trying to manipulate interval-trees is IMHO more complex that what we
need to, and instead of having a dict-of-interval tree, it is almost as
simple to store a table and filter the table on removal.

It is a bit less efficient optimally in some cases, but that should
still be sufficiently fast even with thousands of writers/layer
constraints.

It also remove a dependency, which in this case is I believe a plus.
We could still go 1/2 way and have writers be a dict of (min,max,
writers) but we also don't have _that many_ layer types so it's not
going to be much more performant.

In the end if you squint this really look like sql, as we select writers
based on the layer types,bounds and order-by based on some categories,
So yes this is not sql as we have live objects, and q sql-like library
would be overkill... for now.

----

Simplify iteration a bit.

We just start with all the writers and trim down.
Really in the end we are reinventing a sort-of sql.
