### PR TITLE
Push stack=... through all the reader internal API

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -111,17 +111,17 @@ class _ContributionsIndex:
         return self._commands[command_id][0]
 
     def iter_compatible_readers(
-        self, path: Union[PathLike, List[PathLike]]
+        self, paths: List[str]
     ) -> Iterator[ReaderContribution]:
-        if not path:
+        if not paths:
             return
 
-        if isinstance(path, list):
-            if len({Path(i).suffix for i in path}) > 1:
-                raise ValueError(
-                    "All paths in the stack list must have the same extension."
-                )
-            path = path[0]
+        assert isinstance(paths, list)
+        if len({Path(i).suffix for i in paths}) > 1:
+            raise ValueError(
+                "All paths in the stack list must have the same extension."
+            )
+        path = paths[0]
 
         if os.path.isdir(path):
             yield from self._readers[""]
@@ -413,7 +413,9 @@ class PluginManager:
     def iter_compatible_readers(
         self, path: Union[PathLike, List[PathLike]]
     ) -> Iterator[ReaderContribution]:
-        return self._contrib.iter_compatible_readers(path)
+        if not isinstance(path, list):
+            path = [path]
+        return self._contrib.iter_compatible_readers([str(p) for p in path])
 
     def iter_compatible_writers(
         self, layer_types: Sequence[str]

--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -6,19 +6,22 @@ from typing_extensions import Literal
 
 from . import PluginManager
 from .types import FullLayerData, LayerData, PathLike
+from .manifest.utils import v1_to_v2
 
 if TYPE_CHECKING:
     from .manifest.readers import ReaderContribution
     from .manifest.writers import WriterContribution
 
 
-def read(path: PathLike, *, plugin_name: Optional[str] = None) -> List[LayerData]:
+def read(path: PathLike, *, stack:bool, plugin_name: Optional[str] = None) -> List[LayerData]:
     """Try to read file at `path`, with plugins offering a ReaderContribution.
 
     Parameters
     ----------
     path : str or Path
         Path to the file or resource being read.
+    stack : bool
+        Should the readers stack the read files.
     plugin_name : str, optional
         Optional plugin name.  If provided, only readers from this plugin will be
         tried (it's possible that none will be compatible). by default None
@@ -34,14 +37,25 @@ def read(path: PathLike, *, plugin_name: Optional[str] = None) -> List[LayerData
     ValueError
         If no readers are found or none return data
     """
-    return _read(path, plugin_name=plugin_name)
+    return _read(path, plugin_name=plugin_name, stack=stack)
 
 
 def read_get_reader(
-    path: PathLike, *, plugin_name: Optional[str] = None
+        path: PathLike, *, plugin_name: Optional[str] = None, stack:bool=None
 ) -> Tuple[List[LayerData], ReaderContribution]:
     """Variant of `read` that also returns the `ReaderContribution` used."""
-    return _read(path, plugin_name=plugin_name, return_reader=True)
+
+    if stack is None:
+        # "npe1" old path
+        # Napari 0.4.15 and older, hopefully we can drop this and make stack mandatory
+        new_path, new_stack = v1_to_v2(path)
+        return _read(new_path, plugin_name=plugin_name, return_reader=True, stack=new_stack)
+    else:
+        assert isinstance(path, list)
+        for p in path:
+            assert isinstance(p, str)
+        return _read(path, plugin_name=plugin_name, return_reader=True, stack=stack)
+
 
 
 def write(
@@ -91,8 +105,9 @@ def write_get_writer(
 
 @overload
 def _read(
-    path: PathLike,
+    paths: Sequence[str],
     *,
+    stack:bool,
     plugin_name: Optional[str] = None,
     return_reader: Literal[False] = False,
     _pm=None,
@@ -102,8 +117,9 @@ def _read(
 
 @overload
 def _read(
-    path: PathLike,
+    paths: Sequence[str],
     *,
+    stack:bool,
     plugin_name: Optional[str] = None,
     return_reader: Literal[True],
     _pm=None,
@@ -111,9 +127,13 @@ def _read(
     ...
 
 
+
+
+
 def _read(
-    path: PathLike,
+    paths: Sequence[str],
     *,
+    stack:bool,
     plugin_name: Optional[str] = None,
     return_reader: bool = False,
     _pm: Optional[PluginManager] = None,
@@ -122,16 +142,16 @@ def _read(
     if _pm is None:
         _pm = PluginManager.instance()
 
-    for rdr in _pm.iter_compatible_readers(path):
+    for rdr in _pm.iter_compatible_readers(paths):
         if plugin_name and not rdr.command.startswith(plugin_name):
             continue
-        read_func = rdr.exec(kwargs={"path": path})
+        read_func = rdr.exec(kwargs={"path": paths, "stack":stack})
         if read_func is not None:
             # if the reader function raises an exception here, we don't try to catch it
-            layer_data = read_func(path)
+            layer_data = read_func(paths, stack=stack)
             if layer_data:
                 return (layer_data, rdr) if return_reader else layer_data
-    raise ValueError(f"No readers returned data for {path!r}")
+    raise ValueError(f"No readers returned data for {paths!r}")
 
 
 @overload

--- a/npe2/manifest/readers.py
+++ b/npe2/manifest/readers.py
@@ -1,9 +1,10 @@
 from typing import List, Optional
 
 from pydantic import BaseModel, Extra, Field
+from functools import wraps
 
 from ..types import ReaderFunction
-from .utils import Executable
+from .utils import Executable, v2_to_v1, v1_to_v2
 
 
 class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
@@ -27,6 +28,31 @@ class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
     accepts_directories: bool = Field(
         False, description="Whether this reader accepts directories"
     )
+
+    def exec(self,*, kwargs):
+        """
+        We are trying to simplify internal npe2 logic to always deal with a
+        (list[str], bool) pair instead of Union[PathLike, Seq[Pathlike]]. We
+        thus wrap the Reader Contributions to still give them the old api. Later
+        on we could add a "if manifest.version == 2" or similar to not have this
+        backward-compatibility logic for new plugins.
+        """
+        kwargs = kwargs.copy()
+        stack = kwargs.pop('stack', None)
+        assert stack is not None
+        kwargs['path'] = v2_to_v1( kwargs['path'], stack)
+        callable_ = super().exec(kwargs=kwargs)
+
+        @wraps(callable_)
+        def npe1_compat(paths, *, stack):
+            path = v2_to_v1(paths, stack)
+            return callable_(path)
+        return npe1_compat 
+            
+        
+        
+
+
 
     class Config:
         extra = Extra.forbid

--- a/npe2/manifest/sample_data.py
+++ b/npe2/manifest/sample_data.py
@@ -65,7 +65,7 @@ class SampleDataURI(_SampleDataContribution):
     def open(self, *args, **kwargs) -> List[LayerData]:
         from ..io_utils import read
 
-        return read(self.uri, plugin_name=self.reader_plugin)
+        return read([self.uri], plugin_name=self.reader_plugin, stack=False)
 
     class Config:
         title = "Sample Data URI"

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -33,6 +33,19 @@ if TYPE_CHECKING:
 R = TypeVar("R")
 
 
+def v1_to_v2(path):
+    if isinstance(path, list):
+        return path, True
+    else:
+        return [path], False
+
+def v2_to_v1(paths, stack):
+    if stack:
+        return paths
+    else:
+        assert len(paths) == 1
+        return paths[0]
+
 # TODO: add ParamSpec when it's supported better by mypy
 class Executable(Generic[R]):
     command: str

--- a/tests/test_contributions.py
+++ b/tests/test_contributions.py
@@ -61,8 +61,8 @@ def test_writer_valid_layer_type_expressions(expr, uses_sample_plugin):
 
 
 def test_basic_iter_reader(uses_sample_plugin, plugin_manager: PluginManager, tmp_path):
-    assert not list(plugin_manager.iter_compatible_readers(""))
-    reader = list(plugin_manager.iter_compatible_readers(tmp_path))[0]
+    assert not list(plugin_manager.iter_compatible_readers([""]))
+    reader = list(plugin_manager.iter_compatible_readers([tmp_path]))[0]
     assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
     reader = list(plugin_manager.iter_compatible_readers([tmp_path, tmp_path]))[0]
@@ -103,7 +103,7 @@ def test_sample(uses_sample_plugin, plugin_manager: PluginManager):
 
 
 def test_directory_reader(uses_sample_plugin, plugin_manager: PluginManager, tmp_path):
-    reader = list(plugin_manager.iter_compatible_readers(tmp_path))[0]
+    reader = list(plugin_manager.iter_compatible_readers([tmp_path]))[0]
     assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -7,13 +7,13 @@ SAMPLE_PLUGIN_NAME = "my-plugin"
 
 
 def test_read(uses_sample_plugin):
-    assert read("some.fzzy") == [(None,)]
+    assert read(["some.fzzy"], stack=False) == [(None,)]
 
 
 def test_read_with_plugin(uses_sample_plugin):
     # no such plugin name.... but skips over the sample plugin
     with pytest.raises(ValueError):
-        read("some.fzzy", plugin_name="nope")
+        read(["some.fzzy"], plugin_name="nope", stack=False)
 
 
 def test_read_return_reader(uses_sample_plugin):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -136,7 +136,7 @@ def _assert_sample_enabled(plugin_manager: PluginManager, enabled=True):
             assert plugin_manager.get_command(f"{SAMPLE_PLUGIN_NAME}.hello_world")
 
     # reader
-    cmds = [r.command for r in plugin_manager.iter_compatible_readers("*.fzy")]
+    cmds = [r.command for r in plugin_manager.iter_compatible_readers(["*.fzy"])]
     b = f"{SAMPLE_PLUGIN_NAME}.some_reader" in cmds
     assert b if enabled else not b, f"Reader should {_not}be enabled"
 


### PR DESCRIPTION
There is a tiny bit more we can do once
https://github.com/napari/napari/pull/4130 is merged and we assume a
minimal version of napari that only passes list of str to npe2 and give
it the stack=parameter as well, but it will take a couple releases
for this to be the case