### PR TITLE
Separate dev test from integration test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[docs,testing]
 
+      - name: Test Main docs build
+        run: pytest --color yes -m github_main_only
       - name: Test
         run: pytest --color yes --cov npe2 --cov-report xml --cov-report term-missing
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -m "not github_main_only"
+markers =
+    github_main_only: Test to run only on github main (verify it does not break latest napari docs build)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-from npe2 import PluginManifest
-
 import pytest
+
+from npe2 import PluginManifest
 
 DOCS_DIR = Path(__file__).parent.parent / "_docs"
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 from npe2 import PluginManifest
 
+import pytest
+
 DOCS_DIR = Path(__file__).parent.parent / "_docs"
 
 
@@ -10,6 +12,7 @@ def test_example_manifest():
     assert PluginManifest.from_file(example)
 
 
+@pytest.mark.github_main_only
 def test_render_docs(tmp_path, monkeypatch):
     from _docs.render import main
 


### PR DESCRIPTION
Add a marker that is not ran by default, and add a CI entry to run only
this test

Alternate to #112, #111, closes #108