### PR TITLE
add back deprecated _samples on contributions index

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    DefaultDict,
     Dict,
     Iterable,
     Iterator,
@@ -47,6 +48,11 @@ class _ContributionsIndex:
         self._readers: List[Tuple[str, ReaderContribution]] = list()
         self._writers: List[Tuple[LayerType, int, int, WriterContribution]] = list()
 
+        # DEPRECATED: only here for napari <= 0.4.15 compat.
+        self._samples: DefaultDict[str, List[SampleDataContribution]] = DefaultDict(
+            list
+        )
+
     def index_contributions(self, manifest: PluginManifest):
         ctrb = manifest.contributions
         if not ctrb or manifest.name in self._indexed:
@@ -63,6 +69,10 @@ class _ContributionsIndex:
         for writer in ctrb.writers or ():
             for c in writer.layer_type_constraints():
                 self._writers.append((c.layer_type, *c.bounds, writer))
+
+        # DEPRECATED: only here for napari <= 0.4.15 compat.
+        if ctrb.sample_data:
+            self._samples[manifest.name] = ctrb.sample_data
 
     def remove_contributions(self, key: PluginName) -> None:
         """This must completely remove everything added by `index_contributions`."""
@@ -86,6 +96,9 @@ class _ContributionsIndex:
         ]
 
         self._indexed.remove(key)
+
+        # DEPRECATED: only here for napari <= 0.4.15 compat.
+        self._samples.pop(key, None)
 
     def get_command(self, command_id: str) -> CommandContribution:
         return self._commands[command_id][0]


### PR DESCRIPTION
Looks like I unfortunately [accessed the private `plugin_manager._contrib` object in the npe2 module](https://github.com/napari/napari/blob/4c65afcab0e64d90284a1279f3b707228bb4606d/napari/plugins/_npe2.py#L255) in napari (yet another reminder that even code authors shouldn't use private variables across packages! 😂 ).

#101 modified it a bit, which means that if we were to release a new version of npe2 (which we need to for enable disable), then it would break new napari installations of v0.4.14 and v0.4.15. 

This PR adds back the line needed to maintain compatibility with older versions.
(tested on napari v0.4.14 and napari main)