### PR TITLE
Test napari during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,16 @@ jobs:
         with:
           repository: napari/napari
           path: napari-from-github
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
           python -m pip install ./napari-from-github
+          python -m pip install -e .
+          # bare minimum required to test napari/plugins
           python -m pip install pytest scikit-image[data]
 
       - name: Run napari plugin tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,28 @@ jobs:
         with:
           fail_ci_if_error: true
 
+  test_napari:
+    name: napari tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: napari/napari
+          path: napari-from-github
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install ./napari-from-github
+          python -m pip install pytest scikit-image[data]
+
+      - name: Run napari plugin tests
+        run: pytest napari-from-github/napari/plugins -v --color=yes
+
   deploy:
     name: Deploy
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,19 +52,21 @@ jobs:
           repository: napari/napari
           path: napari-from-github
           fetch-depth: 0
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ./napari-from-github
+          python -m pip install -e ./napari-from-github
           python -m pip install -e .
           # bare minimum required to test napari/plugins
           python -m pip install pytest scikit-image[data]
 
       - name: Run napari plugin tests
-        run: pytest napari-from-github/napari/plugins -v --color=yes
+        run: pytest napari/plugins -v --color=yes
+        working-directory: napari-from-github
 
   deploy:
     name: Deploy


### PR DESCRIPTION
This adds a CI test to make sure that npe2 works on the current napari main (running `pytest napari/plugins`).  could also add a step to checkout the latest release (though, not sure how to grab those tags automatically yet)