### PR TITLE
Fix auto-discovery of plugins for napari <= 0.4.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           python -m pip install -e ./napari-from-github
           python -m pip install -e .
           # bare minimum required to test napari/plugins
-          python -m pip install pytest scikit-image[data] zarr xarray hypothesis
+          python -m pip install pytest scikit-image[data] zarr xarray hypothesis matplotlib
 
       - name: Run napari plugin headless tests
         run: pytest napari/plugins napari/settings napari/layers napari/components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           python -m pip install -e ./napari-from-github
           python -m pip install -e .
           # bare minimum required to test napari/plugins
-          python -m pip install pytest scikit-image[data] zarr
+          python -m pip install pytest scikit-image[data] zarr xarray hypothesis
 
       - name: Run napari plugin headless tests
         run: pytest napari/plugins napari/settings napari/layers napari/components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           python -m pip install -e ./napari-from-github
           python -m pip install -e .
           # bare minimum required to test napari/plugins
-          python -m pip install pytest scikit-image[data]
+          python -m pip install pytest scikit-image[data] zarr
 
       - name: Run napari plugin headless tests
         run: pytest napari/plugins napari/settings napari/layers napari/components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           # bare minimum required to test napari/plugins
           python -m pip install pytest scikit-image[data]
 
-      - name: Run napari plugin tests
-        run: pytest napari/plugins -v --color=yes
+      - name: Run napari plugin headless tests
+        run: pytest napari/plugins napari/settings napari/layers napari/components
         working-directory: napari-from-github
 
   deploy:

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
 __all__ = ["PluginContext", "PluginManager"]
 PluginName = str  # this is `PluginManifest.name`
 
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
+
 
 class _ContributionsIndex:
     def __init__(self) -> None:
@@ -212,6 +217,16 @@ class PluginManager:
         self._contrib = _ContributionsIndex()
         self._manifests: Dict[PluginName, PluginManifest] = {}
         self.events = PluginManagerEvents(self)
+
+        # up to napari 0.4.15, discovery happened in the init here
+        # so if we're running on an older version of napari, we need to discover
+        try:
+            nv = metadata.version("napari")
+        except metadata.PackageNotFoundError:
+            pass
+        else:
+            if tuple(nv.split(".")[:3]) < ("0", "4", "16"):
+                self.discover()
 
     @classmethod
     def instance(cls) -> PluginManager:

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -225,7 +225,13 @@ class PluginManager:
         except metadata.PackageNotFoundError:  # pragma: no cover
             pass
         else:  # pragma: no cover
-            if tuple(nv.split(".")[:3]) < ("0", "4", "16"):
+            vsplit = nv.split(".")[:4]
+            if (
+                "dev" in nv
+                and vsplit < ["0", "4", "16", "dev4"]
+                or "dev" not in nv
+                and vsplit < ["0", "4", "16"]
+            ):
                 self.discover()
 
     @classmethod

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -222,9 +222,9 @@ class PluginManager:
         # so if we're running on an older version of napari, we need to discover
         try:
             nv = metadata.version("napari")
-        except metadata.PackageNotFoundError:
+        except metadata.PackageNotFoundError:  # pragma: no cover
             pass
-        else:
+        else:  # pragma: no cover
             if tuple(nv.split(".")[:3]) < ("0", "4", "16"):
                 self.discover()
 


### PR DESCRIPTION
In #101 greedy discovery of plugins was removed from the plugin manager `__init__`, which means that the user of the plugin manager (napari) should call it when it wants.  But napari <=0.4.15 didn't do that.  so this patch checks the napari version and does it for backwards compatibility.  

I yanked the 0.2.0 release and will release this as 0.2.1 today

Note, this also extends the CI napari tests to include `napari/layers` and `napari/components` as those are actually the tests that failed without this (since they were expecting napari-svg to be discovered... but it wasnt)