### PR TITLE
Disallow mutation on plugin manifest name

### DIFF
--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -52,6 +52,7 @@ class PluginManifest(ImportExportModel):
         ...,
         description="The name of the plugin. Though this field is mandatory, it *must*"
         " match the package `name` as defined in the python package metadata.",
+        allow_mutation=False,
     )
     _validate_name = validator("name", pre=True, allow_reuse=True)(
         _validators.package_name
@@ -224,6 +225,7 @@ class PluginManifest(ImportExportModel):
     class Config:
         underscore_attrs_are_private = True
         extra = Extra.forbid
+        validate_assignment = True
 
     @classmethod
     def discover(


### PR DESCRIPTION
Since we use `manifest.name` as a string key in many places, it seems wise to prevent mutation on the name after instantiation