### PR TITLE
Push stack=... through all the reader internal API, take II

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -114,7 +114,7 @@ class _ContributionsIndex:
     def iter_compatible_readers(self, paths: List[str]) -> Iterator[ReaderContribution]:
         assert isinstance(paths, list)
         if not paths:
-            return
+            return  # pragma: no cover
 
         if len({Path(i).suffix for i in paths}) > 1:
             raise ValueError(

--- a/npe2/manifest/contributions/_readers.py
+++ b/npe2/manifest/contributions/_readers.py
@@ -1,9 +1,10 @@
+from functools import wraps
 from typing import List, Optional
 
 from pydantic import BaseModel, Extra, Field
 
 from ...types import ReaderFunction
-from ..utils import Executable
+from ..utils import Executable, v2_to_v1
 
 
 class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
@@ -35,3 +36,27 @@ class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
         return hash(
             (self.command, tuple(self.filename_patterns), self.accepts_directories)
         )
+
+    def exec(self, *, kwargs):
+        """
+        We are trying to simplify internal npe2 logic to always deal with a
+        (list[str], bool) pair instead of Union[PathLike, Seq[Pathlike]]. We
+        thus wrap the Reader Contributions to still give them the old api. Later
+        on we could add a "if manifest.version == 2" or similar to not have this
+        backward-compatibility logic for new plugins.
+        """
+        kwargs = kwargs.copy()
+        stack = kwargs.pop("stack", None)
+        assert stack is not None
+        kwargs["path"] = v2_to_v1(kwargs["path"], stack)
+        callable_ = super().exec(kwargs=kwargs)
+
+        if callable_ is None:
+            return None
+
+        @wraps(callable_)
+        def npe1_compat(paths, *, stack):
+            path = v2_to_v1(paths, stack)
+            return callable_(path)  # type: ignore
+
+        return npe1_compat

--- a/npe2/manifest/contributions/_readers.py
+++ b/npe2/manifest/contributions/_readers.py
@@ -51,7 +51,7 @@ class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
         kwargs["path"] = v2_to_v1(kwargs["path"], stack)
         callable_ = super().exec(kwargs=kwargs)
 
-        if callable_ is None:
+        if callable_ is None:  # pragma: no cover
             return None
 
         @wraps(callable_)

--- a/npe2/manifest/contributions/_sample_data.py
+++ b/npe2/manifest/contributions/_sample_data.py
@@ -65,7 +65,7 @@ class SampleDataURI(_SampleDataContribution):
     def open(self, *args, **kwargs) -> List[LayerData]:
         from ...io_utils import read
 
-        return read(self.uri, plugin_name=self.reader_plugin)
+        return read([self.uri], plugin_name=self.reader_plugin, stack=False)
 
     class Config:
         title = "Sample Data URI"

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -35,6 +35,21 @@ if TYPE_CHECKING:
             ...
 
 
+def v1_to_v2(path):
+    if isinstance(path, list):
+        return path, True
+    else:
+        return [path], False
+
+
+def v2_to_v1(paths, stack):
+    if stack:
+        return paths
+    else:
+        assert len(paths) == 1
+        return paths[0]
+
+
 R = TypeVar("R")
 SHIM_NAME_PREFIX = "__npe1shim__."
 

--- a/npe2/types.py
+++ b/npe2/types.py
@@ -1,5 +1,3 @@
-import warnings
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -28,19 +26,6 @@ PathOrPaths = Union[PathLike, Sequence[PathLike]]
 PythonName = NewType("PythonName", str)
 
 # Layer-related types
-
-
-def _ensure_str_or_seq_str(path):
-    if isinstance(path, Path) or (
-        isinstance(path, (list, tuple)) and any([isinstance(p, Path) for p in path])
-    ):
-        warnings.warn(
-            "Npe2 receive a `Path` or a list of `Path`s, instead of `str`,"
-            " this will  become an error in the future and is likely a"
-            " napari bug. Please fill and issue.",
-            UserWarning,
-            stacklevel=3,
-        )
 
 
 class ArrayLike(Protocol):

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,11 +61,11 @@ docs =
     Jinja2
 testing =
     magicgui
+    napari-plugin-engine
     napari-svg
     numpy
     pytest
     pytest-cov
-    napari_plugin_engine
     rich
 
 [bdist_wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ testing =
     numpy
     pytest
     pytest-cov
+    napari_plugin_engine
     rich
 
 [bdist_wheel]

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from npe2 import read, read_get_reader, write, write_get_writer

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -22,6 +22,12 @@ def test_read_return_reader(uses_sample_plugin):
     assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 
+def test_read_return_reader_with_stack(uses_sample_plugin):
+    data, reader = read_get_reader(["some.fzzy"], stack=True)
+    assert data == [(None,)]
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+
 def test_read_list(uses_sample_plugin):
     data, reader = read_get_reader(["some.fzzy", "other.fzzy"])
     assert data == [(None,)]

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -3,19 +3,19 @@ from pathlib import Path
 import pytest
 
 from npe2 import read, read_get_reader, write, write_get_writer
-from npe2.types import FullLayerData, _ensure_str_or_seq_str
+from npe2.types import FullLayerData
 
 SAMPLE_PLUGIN_NAME = "my-plugin"
 
 
 def test_read(uses_sample_plugin):
-    assert read("some.fzzy") == [(None,)]
+    assert read(["some.fzzy"], stack=False) == [(None,)]
 
 
 def test_read_with_plugin(uses_sample_plugin):
     # no such plugin name.... but skips over the sample plugin
     with pytest.raises(ValueError):
-        read("some.fzzy", plugin_name="nope")
+        read(["some.fzzy"], plugin_name="nope", stack=False)
 
 
 def test_read_return_reader(uses_sample_plugin):
@@ -60,8 +60,3 @@ def test_writer_single_layer_api_exec(uses_sample_plugin):
     # This writer doesn't do anything but type check.
     paths = write("test/path", [([], {}, "labels")])
     assert len(paths) == 1
-
-
-def test_ensure_coverage():
-    with pytest.warns(UserWarning):
-        _ensure_str_or_seq_str(Path("."))


### PR DESCRIPTION
There is a tiny bit more we can do once
napari/napari#4130 is merged and we assume a
minimal version of napari that only passes list of str to npe2 and give
it the stack=parameter as well, but it will take a couple releases
for this to be the case

Redo of #109 (was too complicated to rebase), so remade in a separate PR