### PR TITLE
Turn off npe1 discovery by default

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -254,7 +254,9 @@ class PluginManager:
 
     # Discovery, activation, enablement
 
-    def discover(self, paths: Sequence[str] = (), clear=False) -> None:
+    def discover(
+        self, paths: Sequence[str] = (), clear=False, include_npe1=False
+    ) -> None:
         """Discover and index plugin manifests in the environment.
 
         Parameters
@@ -266,6 +268,9 @@ class PluginManager:
             Clear and re-index the environment.  If `False` (the default),
             calling discover again will only register and index newly
             discovered plugins. (Existing manifests will not be re-indexed)
+        include_npe1 : bool
+            Whether to detect npe1 plugins as npe1_adapters during discovery.
+            By default `False`.
         """
         if clear:
             self._contrib = _ContributionsIndex()
@@ -273,7 +278,11 @@ class PluginManager:
 
         with self.events.plugins_registered.paused(lambda a, b: (a[0] | b[0],)):
             for result in PluginManifest.discover(paths=paths):
-                if result.manifest and result.manifest.name not in self._manifests:
+                if (
+                    result.manifest
+                    and result.manifest.name not in self._manifests
+                    and (include_npe1 or not isinstance(result.manifest, NPE1Adapter))
+                ):
                     self.register(result.manifest, warn_disabled=False)
 
     def index_npe1_adapters(self):

--- a/tests/test_npe1_adapter.py
+++ b/tests/test_npe1_adapter.py
@@ -22,7 +22,7 @@ def test_adapter_no_npe1():
 def test_npe1_adapter(uses_npe1_plugin, mock_cache: Path):
     """Test that the plugin manager detects npe1 plugins, and can index contribs"""
     pm = PluginManager()
-    pm.discover()
+    pm.discover(include_npe1=True)
 
     # we've found an adapter
     assert len(pm._npe1_adapters) == 1
@@ -54,7 +54,7 @@ def test_npe1_adapter(uses_npe1_plugin, mock_cache: Path):
 
         mock.reset_mock()
         # clear and rediscover... this time we expect the cache to kick in
-        pm.discover(clear=True)
+        pm.discover(clear=True, include_npe1=True)
         assert len(pm._npe1_adapters) == 1
         pm.index_npe1_adapters()
         assert len(pm._npe1_adapters) == 0
@@ -64,7 +64,7 @@ def test_npe1_adapter(uses_npe1_plugin, mock_cache: Path):
 def test_npe1_adapter_cache(uses_npe1_plugin, mock_cache: Path):
     """Test that we can clear cache, etc.."""
     pm = PluginManager()
-    pm.discover()
+    pm.discover(include_npe1=True)
 
     with patch.object(
         _npe1_adapter,
@@ -83,7 +83,7 @@ def test_npe1_adapter_cache(uses_npe1_plugin, mock_cache: Path):
         assert not mf._cache_path().exists()
 
         mock.reset_mock()
-        pm.discover(clear=True)
+        pm.discover(clear=True, include_npe1=True)
         pm.index_npe1_adapters()
         mf = pm.get_manifest("npe1-plugin")
         assert isinstance(mf, _npe1_adapter.NPE1Adapter)
@@ -97,7 +97,7 @@ def test_npe1_adapter_cache(uses_npe1_plugin, mock_cache: Path):
 
 def _get_mf() -> _npe1_adapter.NPE1Adapter:
     pm = PluginManager.instance()
-    pm.discover()
+    pm.discover(include_npe1=True)
     pm.index_npe1_adapters()
     mf = pm.get_manifest("npe1-plugin")
     assert isinstance(mf, _npe1_adapter.NPE1Adapter)


### PR DESCRIPTION
This turns off discovery of npe1 plugins by defaulting, instead accepting an argument to `PluginManager.discover()` to turn on the shim.  this will make it a bit easier for napari to control this behavior, and allow us to release the current main without breaking napari
