### PR TITLE
Fix plack problem on pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
         exclude: tests/npe1-plugin/setup.cfg
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade


### PR DESCRIPTION
Black used the private API of the `click` package which was broken in the last release:
https://github.com/psf/black/issues/2964

There are two options. Pin click version or update black. I suggest the second one. Like in napari: https://github.com/napari/napari/pull/4327

Also updated setup-cfg-fmt. 