### PR TITLE
Auto update changelog workflow

### DIFF
--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -1,0 +1,27 @@
+name: Update Changelog
+on:
+  workflow_dispatch:
+    inputs:
+      next_tag:
+        description: "Next version tag (`vX.Y.Z`)"
+        required: true
+
+jobs:
+  changelog:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: "✏️ Generate release changelog"
+        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        with:
+          futureRelease: ${{ github.event.inputs.next_tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: napari/npe2
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Automatic changelog update
+          title: Automatic Changelog update
+          branch: update-changelog


### PR DESCRIPTION
I'm not a ruby person I didn't managed to get the github changelog update gem to work, so why not make it a workflow that can be ran by a press of a button ?  