### PR TITLE
Fix codeblock directive in docstring

### DIFF
--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -237,20 +237,20 @@ class PluginManifest(ImportExportModel):
         This function searches for installed python packages with a matching
         entry point group and then attempts to resolve the manifest file.
 
-        The manifest file should be specified in the plugin's `setup.cfg` or
-        `setup.py` file using the [entry point group][1]: "napari.manifest".
+        The manifest file should be specified in the plugin's ``setup.cfg`` or
+        ``setup.py`` file using the [entry point group][1]: "napari.manifest".
         For example, this would be the section for a plugin "npe-tester" with
         "napari.yaml" as the manifest file:
 
-        ```cfg
-        [options.entry_points]
-        napari.manifest =
-            npe2-tester = npe2_tester:napari.yaml
-        ```
+        .. code-block:: cfg
+
+            [options.entry_points]
+            napari.manifest =
+                npe2-tester = npe2_tester:napari.yaml
 
         The manifest file is specified relative to the submodule root path.
         So for the example it will be loaded from:
-        `<path/to/npe2-tester>/napari.yaml`.
+        ``<path/to/npe2-tester>/napari.yaml``.
 
         [1]: https://packaging.python.org/specifications/entry-points/
 


### PR DESCRIPTION
Changes codeblock to rst syntax (it was previously written in markdown syntax).

This eliminates errors when building the napari docs.