### PR TITLE
Fix writer order preference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
         additional_dependencies:
         - flake8-typing-imports
         - flake8-bugbear
-        - flake8-docstrings
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -169,7 +169,7 @@ class _ContributionsIndex:
             nbounds = sum(not c.is_zero() for c in writer.layer_type_constraints())
             return (no_ext, nbounds)
 
-        yield from candidates
+        yield from sorted(candidates, key=_writer_key)
 
 
 class PluginManagerEvents(SignalGroup):

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -160,25 +160,15 @@ class _ContributionsIndex:
             else:
                 break
 
-        def _writer_key(writer: WriterContribution) -> Tuple[bool, int, int, List[str]]:
+        def _writer_key(writer: WriterContribution) -> Tuple[bool, int]:
             # 1. writers with no file extensions (like directory writers) go last
             no_ext = len(writer.filename_extensions) == 0
 
             # 2. more "specific" writers first
             nbounds = sum(not c.is_zero() for c in writer.layer_type_constraints())
+            return (no_ext, nbounds)
 
-            # 3. then sort by the number of listed extensions
-            #    (empty set of extensions goes last)
-            ext_len = len(writer.filename_extensions)
-
-            # 4. finally group related extensions together
-            exts = writer.filename_extensions
-            return (no_ext, nbounds, ext_len, exts)
-
-        yield from sorted(
-            candidates,
-            key=_writer_key,
-        )
+        yield from sorted(candidates, key=_writer_key)
 
 
 class PluginManagerEvents(SignalGroup):

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -153,10 +153,11 @@ class _ContributionsIndex:
                 if layer == lt and (min_ <= counts[lt] < max_)
             }
 
-        candidates = {w for _, _, _, w in self._writers}
+        # keep ordered without duplicates
+        candidates = list({w: None for _, _, _, w in self._writers})
         for lt in LayerType:
             if candidates:
-                candidates &= _get_candidates(lt)
+                candidates = [i for i in candidates if i in _get_candidates(lt)]
             else:
                 break
 
@@ -168,7 +169,7 @@ class _ContributionsIndex:
             nbounds = sum(not c.is_zero() for c in writer.layer_type_constraints())
             return (no_ext, nbounds)
 
-        yield from sorted(candidates, key=_writer_key)
+        yield from candidates
 
 
 class PluginManagerEvents(SignalGroup):

--- a/tests/test_contributions.py
+++ b/tests/test_contributions.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from npe2 import PluginManager, PluginManifest
+from npe2 import DynamicPlugin, PluginManager, PluginManifest
 from npe2.manifest.contributions import (
     CommandContribution,
     SampleDataGenerator,
@@ -39,6 +39,23 @@ def test_writer_ranges(param, uses_sample_plugin, plugin_manager: PluginManager)
     )
 
     assert nwriters == expected_count
+
+
+def test_writer_priority():
+    """Contributions listed earlier in the manifest should be preferred."""
+    pm = PluginManager()
+    with DynamicPlugin(name="my_plugin", plugin_manager=pm) as plg:
+
+        @plg.contribute.writer(filename_extensions=["*.tif"], layer_types=["image"])
+        def my_writer1(path, data):
+            ...
+
+        @plg.contribute.writer(filename_extensions=["*.abc"], layer_types=["image"])
+        def my_writer2(path, data):
+            ...
+
+        writers = list(pm.iter_compatible_writers(["image"]))
+        assert writers[0].command == "my_plugin.my_writer1"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fixes #129, ensuring that – all else being equal – writers declared earlier in a plugin's manifest have priority over later ones 