### PR TITLE
Revert menu restriction (#160)

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -453,8 +453,7 @@ class PluginManager:
 
     def iter_menu(self, menu_key: str) -> Iterator[MenuItem]:
         for mf in self.iter_manifests(disabled=False):
-            if mf.contributions.menus is not None:
-                yield from mf.contributions.menus.get(menu_key, ())
+            yield from getattr(mf.contributions.menus, menu_key, ())
 
     def iter_themes(self) -> Iterator[ThemeContribution]:
         for mf in self.iter_manifests(disabled=False):

--- a/npe2/manifest/contributions/__init__.py
+++ b/npe2/manifest/contributions/__init__.py
@@ -1,6 +1,6 @@
 from ._commands import CommandContribution
 from ._contributions import ContributionPoints
-from ._menus import MenuCommand, MenuItem, Submenu
+from ._menus import MenuCommand, MenuItem, MenusContribution, Submenu
 from ._readers import ReaderContribution
 from ._sample_data import SampleDataContribution, SampleDataGenerator, SampleDataURI
 from ._submenu import SubmenuContribution
@@ -15,6 +15,7 @@ __all__ = [
     "LayerTypeConstraint",
     "MenuCommand",
     "MenuItem",
+    "MenusContribution",
     "ReaderContribution",
     "SampleDataContribution",
     "SampleDataGenerator",

--- a/npe2/manifest/contributions/_contributions.py
+++ b/npe2/manifest/contributions/_contributions.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
 from ._commands import CommandContribution
-from ._menus import MenuItem
+from ._menus import MenusContribution
 from ._readers import ReaderContribution
 from ._sample_data import SampleDataContribution
 from ._submenu import SubmenuContribution
@@ -20,8 +20,7 @@ class ContributionPoints(BaseModel):
     sample_data: Optional[List[SampleDataContribution]]
     themes: Optional[List[ThemeContribution]]
 
-    # We use a dict for menus to allow for keys with `/`
-    menus: Optional[Dict[str, List[MenuItem]]] = Field(None, hide_docs=True)
+    menus: Optional[MenusContribution] = Field(None, hide_docs=True)
     submenus: Optional[List[SubmenuContribution]] = Field(None, hide_docs=True)
 
     # configuration: Optional[JsonSchemaObject]

--- a/npe2/manifest/contributions/_submenu.py
+++ b/npe2/manifest/contributions/_submenu.py
@@ -1,16 +1,13 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel
 from pydantic.fields import Field
 
-from .. import _validators
 from ._icon import Icon
-from ._menus import MenuItem
 
 
 class SubmenuContribution(BaseModel):
     id: str = Field(description="Identifier of the menu to display as a submenu.")
-    _valid_id = validator("id", allow_reuse=True)(_validators.command_id)
     label: str = Field(
         description="The label of the menu item which leads to this submenu."
     )
@@ -21,7 +18,4 @@ class SubmenuContribution(BaseModel):
             " Either a file path, an object with file paths for dark and light"
             "themes, or a theme icon references, like `$(zap)`"
         ),
-    )
-    contents: List[MenuItem] = Field(
-        description="The contents of the submenu, commands and other submenus."
     )

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -62,14 +62,13 @@ contributions:
       autogenerate: true
   menus:
     /napari/layer_context:
-      - submenu: my-plugin.mysubmenu
+      - submenu: mysubmenu
       - command: my-plugin.hello_world
+    mysubmenu:
+      - command: my-plugin.another_command
   submenus:
-    - id: my-plugin.mysubmenu
+    - id: mysubmenu
       label: My SubMenu
-      contents:
-        - command: my-plugin.another_command
-        - command: my-plugin.another_command
   themes:
     - label: "SampleTheme"
       id: "sample_theme"

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -54,7 +54,7 @@ def test_plugin_manager(pm: PluginManager):
 
     assert pm.get_command(f"{SAMPLE_PLUGIN_NAME}.hello_world")
 
-    assert pm.get_submenu(f"{SAMPLE_PLUGIN_NAME}.mysubmenu")
+    assert pm.get_submenu("mysubmenu")
     with pytest.raises(KeyError):
         pm.get_submenu("not-a-submenu")
     assert len(list(pm.iter_menu("/napari/layer_context"))) == 2


### PR DESCRIPTION
This reverts #160, which i think we've decided may not be the direction we want to go in after all (see discussion in #161 and related links)... primarily since we likely need plugins to be able to contribute to other plugins menus.

This is also the one thing that's causing our napari test fails.

After this: consider #175 