### PR TITLE
hide docs again in napari menus (Fix napari docs build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
+
   test:
     name: ${{ matrix.platform }} (${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}
@@ -67,6 +68,25 @@ jobs:
       - name: Run napari plugin headless tests
         run: pytest -W 'ignore::DeprecationWarning' napari/plugins napari/settings napari/layers napari/components
         working-directory: napari-from-github
+
+  test_docs_render:
+    name: docs render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build schema
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          python -m npe2.manifest.schema > _schema.json
+      - name: Test rendering docs
+        run: |
+          python _docs/render.py
+        env:
+          NPE2_SCHEMA: "_schema.json"
 
   deploy:
     name: Deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,10 @@ jobs:
       - name: Build schema
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e .[docs]
           python -m npe2.manifest.schema > _schema.json
       - name: Test rendering docs
-        run: |
-          python _docs/render.py
+        run: python _docs/render.py
         env:
           NPE2_SCHEMA: "_schema.json"
 

--- a/_docs/render.py
+++ b/_docs/render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
 import re
 import sys
 from contextlib import contextmanager
@@ -183,8 +184,12 @@ def main(dest: Path = _BUILD):
 
     dest.mkdir(exist_ok=True, parents=True)
     schema = PluginManifest.schema()
-    with urlopen(SCHEMA_URL) as response:
-        schema = json.load(response)
+    if local_schema := os.getenv("NPE2_SCHEMA"):
+        with open(local_schema) as f:
+            schema = json.load(f)
+    else:
+        with urlopen(SCHEMA_URL) as response:
+            schema = json.load(response)
 
     contributions = schema["definitions"]["ContributionPoints"]["properties"]
     context = {

--- a/npe2/manifest/contributions/_contributions.py
+++ b/npe2/manifest/contributions/_contributions.py
@@ -20,7 +20,9 @@ class ContributionPoints(BaseModel):
     sample_data: Optional[List[SampleDataContribution]]
     themes: Optional[List[ThemeContribution]]
 
-    menus: Dict[str, List[MenuItem]] = Field(default_factory=dict, description="")
+    menus: Dict[str, List[MenuItem]] = Field(
+        default_factory=dict, description="", hide_docs=True
+    )
     submenus: Optional[List[SubmenuContribution]] = Field(None, hide_docs=True)
 
     # configuration: Optional[JsonSchemaObject]

--- a/npe2/manifest/contributions/_contributions.py
+++ b/npe2/manifest/contributions/_contributions.py
@@ -20,9 +20,7 @@ class ContributionPoints(BaseModel):
     sample_data: Optional[List[SampleDataContribution]]
     themes: Optional[List[ThemeContribution]]
 
-    menus: Dict[str, List[MenuItem]] = Field(
-        default_factory=dict, description="", hide_docs=True
-    )
+    menus: Dict[str, List[MenuItem]] = Field(default_factory=dict, hide_docs=True)
     submenus: Optional[List[SubmenuContribution]] = Field(None, hide_docs=True)
 
     # configuration: Optional[JsonSchemaObject]


### PR DESCRIPTION
forgot to add `hide_docs` in Contributions.menus.

Actually, just realizing that since we use the schema.json from the latest release (not from main), this actually requires a new release to fix building docs on napari.  So this PR adds a new test to make sure that docs are building correctly.  (I can't remember the backstory, but the docs build test only runs on main, and it still for some reason, failed... so this adds another test that should catch it)