### PR TITLE
add npe2pm TestPluginManager fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Test Main docs build
         run: pytest --color yes -m github_main_only
       - name: Test
-        run: pytest --color yes --cov npe2 --cov-report xml --cov-report term-missing
+        run: |
+          coverage run --source=npe2 -m pytest --color yes
+          coverage xml
+          coverage report --show-missing
 
       - name: Coverage
         uses: codecov/codecov-action@v3

--- a/npe2/_dynamic_plugin.py
+++ b/npe2/_dynamic_plugin.py
@@ -47,10 +47,13 @@ class DynamicPlugin:
     Parameters
     ----------
     name : str
-        _description_, by default "temp-plugin"
+        Optional name for this temporary plugin., by default "temp-plugin"
     plugin_manager : Optional[PluginManager]
         A plugin manager instance with which to associate this plugin. If `None` (the
         default), the global `PluginManager.instance()` will be used.
+    manifest: Optional[PluginManifest],
+        Optionally provide a manifest to use for this plugin. If not provided, a new
+        manifest will be created.
 
     Examples
     --------
@@ -74,20 +77,20 @@ class DynamicPlugin:
 
     @property
     def name(self) -> str:
-        """Name of the plugin"""
+        """Name of the plugin."""
         return self.manifest.name
 
     @property
     def display_name(self) -> str:
-        """Display name of the plugin"""
+        """Display name of the plugin."""
         return self.manifest.display_name
 
     def cleanup(self) -> None:
-        """Remove this plugin from its plugin manager"""
+        """Remove this plugin from its plugin manager."""
         self.plugin_manager.unregister(self.manifest.name)
 
     def register(self) -> None:
-        """Remove this plugin from its plugin manager"""
+        """Remove this plugin from its plugin manager."""
         self.plugin_manager.register(self.manifest)
 
     def clear(self) -> None:

--- a/npe2/_dynamic_plugin.py
+++ b/npe2/_dynamic_plugin.py
@@ -63,8 +63,12 @@ class DynamicPlugin:
         self,
         name: str = "temp-plugin",
         plugin_manager: Optional[PluginManager] = None,
+        manifest: Optional[PluginManifest] = None,
     ) -> None:
-        self.manifest = PluginManifest(name=name)
+        if isinstance(manifest, PluginManifest):
+            self.manifest = manifest
+        else:
+            self.manifest = PluginManifest(name=name)
         self.contribute = ContributionDecorators(self)
         self._pm = plugin_manager
 

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -288,14 +288,16 @@ class PluginManager:
         Parameters
         ----------
         manifest_or_package : Union[PluginManifest, str]
-            _description_
+            Either a PluginManifest instance or a string. If a string, should be either
+            the name of a plugin package, or a path to a plugin manifest file.
         warn_disabled : bool, optional
-            _description_, by default True
+            If True, emits a warning if the plugin being registered is marked as
+            disabled, by default True.
 
         Raises
         ------
         ValueError
-            _description_
+            If a plugin with the same name is already registered.
         """
         if isinstance(manifest_or_package, str):
             if Path(manifest_or_package).is_file():

--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -280,8 +280,34 @@ class PluginManager:
             while self._npe1_adapters:
                 self._contrib.index_contributions(self._npe1_adapters.pop())
 
-    def register(self, manifest: PluginManifest, warn_disabled=True) -> None:
-        """Register a plugin manifest"""
+    def register(
+        self, manifest_or_package: Union[PluginManifest, str], warn_disabled=True
+    ) -> None:
+        """Register a plugin manifest, path to manifest file, or a plugin (package) name.
+
+        Parameters
+        ----------
+        manifest_or_package : Union[PluginManifest, str]
+            _description_
+        warn_disabled : bool, optional
+            _description_, by default True
+
+        Raises
+        ------
+        ValueError
+            _description_
+        """
+        if isinstance(manifest_or_package, str):
+            if Path(manifest_or_package).is_file():
+                manifest = PluginManifest.from_file(manifest_or_package)
+            else:
+                manifest = PluginManifest.from_distribution(manifest_or_package)
+        elif isinstance(manifest_or_package, PluginManifest):
+            manifest = manifest_or_package
+        else:  # pragma: no cover
+            raise TypeError(
+                "The first argument to register must be a string or a PluginManifest."
+            )
         if manifest.name in self._manifests:
             raise ValueError(f"A manifest with name {manifest.name!r} already exists.")
 

--- a/npe2/_pytest_plugin.py
+++ b/npe2/_pytest_plugin.py
@@ -15,7 +15,7 @@ class TestPluginManager(PluginManager):
         import warnings
 
         warnings.warn(
-            "TestPluginManager is unable to discover plugins.  "
+            "TestPluginManager is unable to discover plugins. "
             "Please use `tmp_plugin()` to add a plugin to this plugin manager."
         )
         return None
@@ -48,7 +48,7 @@ class TestPluginManager(PluginManager):
             be sure to enter the DynamicPlugin context to register the plugin.
         """
         if manifest is not None:
-            if package or name:
+            if package or name:  # pragma: no cover
                 warnings.warn(
                     "`manifest` overrides the `package` and `name` arguments. "
                     "Please provide only one."
@@ -58,7 +58,7 @@ class TestPluginManager(PluginManager):
             else:
                 mf = PluginManifest.from_file(manifest)
         elif package:
-            if name:
+            if name:  # pragma: no cover
                 warnings.warn(
                     "`package` overrides the `name` argument. Please provide only one."
                 )
@@ -66,7 +66,7 @@ class TestPluginManager(PluginManager):
         else:
             name = name or "tmp_plugin"
             i = 0
-            while name in self._manifests:
+            while name in self._manifests:  # pragma: no cover
                 # guarantee that name is unique
                 name = f"{name}_{i}"
                 i += 1

--- a/npe2/_pytest_plugin.py
+++ b/npe2/_pytest_plugin.py
@@ -46,6 +46,17 @@ class TestPluginManager(PluginManager):
         -------
         DynamicPlugin
             be sure to enter the DynamicPlugin context to register the plugin.
+
+        Examples
+        --------
+        >>> def test_something_with_only_my_plugin_registered(npe2pm):
+        ...    with npe2pm.tmp_plugin(package='my-plugin') as plugin:
+        ...        ...
+
+        >>> def test_something_with_specific_manifest_file_registered(npe2pm):
+        ...    mf_file = Path(__file__).parent / 'my_manifest.yaml'
+        ...    with npe2pm.tmp_plugin(manifest=str(mf_file)) as plugin:
+        ...        ...
         """
         if manifest is not None:
             if package or name:  # pragma: no cover
@@ -76,7 +87,15 @@ class TestPluginManager(PluginManager):
 
 @pytest.fixture
 def npe2pm():
-    """Return mocked Global plugin manager instance, unable to discover plugins."""
+    """Return mocked Global plugin manager instance, unable to discover plugins.
+
+    Examples
+    --------
+    >>> @pytest.fixture(autouse=True)
+    ... def mock_npe2_pm(npe2pm):
+    ...     # Auto-use this fixture to prevent plugin discovery.
+    ...     return npe2pm
+    """
     _pm = TestPluginManager()
     with patch("npe2.PluginManager.instance", return_value=_pm):
         yield _pm

--- a/npe2/_pytest_plugin.py
+++ b/npe2/_pytest_plugin.py
@@ -1,0 +1,82 @@
+import warnings
+from typing import Optional, Union
+from unittest.mock import patch
+
+import pytest
+
+from npe2 import DynamicPlugin, PluginManager, PluginManifest
+
+
+class TestPluginManager(PluginManager):
+    """A PluginManager subclass suitable for use in testing."""
+
+    def discover(self, *_, **__) -> None:
+        """Discovery is blocked in the TestPluginManager."""
+        import warnings
+
+        warnings.warn(
+            "TestPluginManager is unable to discover plugins.  "
+            "Please use `tmp_plugin()` to add a plugin to this plugin manager."
+        )
+        return None
+
+    def tmp_plugin(
+        self,
+        manifest: Optional[Union[PluginManifest, str]] = None,
+        package: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> DynamicPlugin:
+        """Create a DynamicPlugin instance using this plugin manager.
+
+        If providing arguments, provide only one of 'manifest', 'package', 'name'.
+
+        Parameters
+        ----------
+        manifest : Union[PluginManifest, str]
+            A manifest to use for this plugin. If a string, it is assumed to be the
+            path to a manifest file (which must exist), otherwise must be a
+            PluginManifest instance.
+        package : str
+            Name of an installed plugin/package.
+        name : str
+            If neither `manifest` or `package` is provided, a new DynamicPlugin is
+            created with this name, by default "tmp_plugin"
+
+        Returns
+        -------
+        DynamicPlugin
+            be sure to enter the DynamicPlugin context to register the plugin.
+        """
+        if manifest is not None:
+            if package or name:
+                warnings.warn(
+                    "`manifest` overrides the `package` and `name` arguments. "
+                    "Please provide only one."
+                )
+            if isinstance(manifest, PluginManifest):
+                mf = manifest
+            else:
+                mf = PluginManifest.from_file(manifest)
+        elif package:
+            if name:
+                warnings.warn(
+                    "`package` overrides the `name` argument. Please provide only one."
+                )
+            mf = PluginManifest.from_distribution(package)
+        else:
+            name = name or "tmp_plugin"
+            i = 0
+            while name in self._manifests:
+                # guarantee that name is unique
+                name = f"{name}_{i}"
+                i += 1
+            mf = PluginManifest(name=name)
+        return DynamicPlugin(mf.name, plugin_manager=self, manifest=mf)
+
+
+@pytest.fixture
+def npe2pm():
+    """Return mocked Global plugin manager instance, unable to discover plugins."""
+    _pm = TestPluginManager()
+    with patch("npe2.PluginManager.instance", return_value=_pm):
+        yield _pm

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ zip_safe = False
 [options.entry_points]
 console_scripts =
     npe2 = npe2.cli:main
+pytest11 =
+    npe2 = npe2._pytest_plugin
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ testing =
     napari-svg
     numpy
     pytest
+    pytest-cov
     rich
 
 [bdist_wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ testing =
     napari-svg
     numpy
     pytest
-    pytest-cov
     rich
 
 [bdist_wheel]

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -67,6 +67,20 @@ def test_plugin_manager(pm: PluginManager):
     assert SAMPLE_PLUGIN_NAME not in pm._contexts
 
 
+def test_plugin_manager_register(sample_path):
+    sys.path.append(str(sample_path))
+    try:
+        pm = PluginManager()
+        pm.register(str(sample_path / "my_plugin" / "napari.yaml"))
+        assert "my-plugin" in pm._manifests
+        pm.unregister("my-plugin")
+        assert "my-plugin" not in pm._manifests
+        pm.register("my_plugin")
+        assert "my-plugin" in pm._manifests
+    finally:
+        sys.path.remove(str(sample_path))
+
+
 def test_plugin_manager_raises(pm: PluginManager):
     with pytest.raises(KeyError):
         pm.get_manifest("not-a-pluginxxx")

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -6,7 +6,7 @@ CASE1 = """
 from npe2._pytest_plugin import TestPluginManager
 from npe2 import PluginManager
 
-def test_make_viewer(npe2pm):
+def test_something_1(npe2pm):
     assert isinstance(npe2pm, TestPluginManager)
     assert PluginManager.instance() is npe2pm
 """
@@ -14,7 +14,7 @@ def test_make_viewer(npe2pm):
 CASE2 = """
 import pytest
 
-def test_make_viewer(npe2pm):
+def test_something_2(npe2pm):
     with pytest.warns(UserWarning, match='unable to discover plugins'):
         npe2pm.discover()
 """
@@ -22,7 +22,7 @@ def test_make_viewer(npe2pm):
 CASE3 = """
 from npe2 import DynamicPlugin
 
-def test_make_viewer(npe2pm):
+def test_something_3(npe2pm):
     with npe2pm.tmp_plugin(name='some_name') as plugin:
         assert isinstance(plugin, DynamicPlugin)
         assert plugin.name in npe2pm._manifests
@@ -31,7 +31,7 @@ def test_make_viewer(npe2pm):
 CASE4 = """
 from npe2 import PluginManifest
 
-def test_make_viewer(npe2pm):
+def test_something_4(npe2pm):
     mf = PluginManifest(name='some_name')
     with npe2pm.tmp_plugin(manifest=mf) as plugin:
         assert plugin.name in npe2pm._manifests
@@ -42,7 +42,7 @@ CASE5 = """
 import pytest
 from importlib.metadata import PackageNotFoundError
 
-def test_make_viewer(npe2pm):
+def test_something_5(npe2pm):
     with pytest.raises(PackageNotFoundError):
         npe2pm.tmp_plugin(package='somepackage')
 """
@@ -50,7 +50,7 @@ def test_make_viewer(npe2pm):
 CASE6 = """
 import pytest
 
-def test_make_viewer(npe2pm):
+def test_something_6(npe2pm):
     with pytest.raises(FileNotFoundError):
         npe2pm.tmp_plugin(manifest='some_path.yaml')
 """
@@ -58,7 +58,7 @@ def test_make_viewer(npe2pm):
 
 @pytest.mark.parametrize("case", [CASE1, CASE2, CASE3, CASE4, CASE5, CASE6])
 def test_npe2pm_fixture(pytester: pytest.Pytester, case):
-    """Make sure that our make_napari_viewer plugin works."""
+    """Make sure that the npe2pm fixture works."""
 
     # create a temporary pytest test file
     pytester.makepyfile(case)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,65 @@
+import pytest
+
+pytest_plugins = "pytester"
+
+CASE1 = """
+from npe2._pytest_plugin import TestPluginManager
+from npe2 import PluginManager
+
+def test_make_viewer(npe2pm):
+    assert isinstance(npe2pm, TestPluginManager)
+    assert PluginManager.instance() is npe2pm
+"""
+
+CASE2 = """
+import pytest
+
+def test_make_viewer(npe2pm):
+    with pytest.warns(UserWarning, match='unable to discover plugins'):
+        npe2pm.discover()
+"""
+
+CASE3 = """
+from npe2 import DynamicPlugin
+
+def test_make_viewer(npe2pm):
+    with npe2pm.tmp_plugin(name='some_name') as plugin:
+        assert isinstance(plugin, DynamicPlugin)
+        assert plugin.name in npe2pm._manifests
+"""
+
+CASE4 = """
+from npe2 import PluginManifest
+
+def test_make_viewer(npe2pm):
+    mf = PluginManifest(name='some_name')
+    with npe2pm.tmp_plugin(manifest=mf) as plugin:
+        assert plugin.name in npe2pm._manifests
+        assert plugin.manifest is mf
+"""
+
+CASE5 = """
+import pytest
+from importlib.metadata import PackageNotFoundError
+
+def test_make_viewer(npe2pm):
+    with pytest.raises(PackageNotFoundError):
+        npe2pm.tmp_plugin(package='somepackage')
+"""
+
+CASE6 = """
+import pytest
+
+def test_make_viewer(npe2pm):
+    with pytest.raises(FileNotFoundError):
+        npe2pm.tmp_plugin(manifest='some_path.yaml')
+"""
+
+
+@pytest.mark.parametrize("case", [CASE1, CASE2, CASE3, CASE4, CASE5, CASE6])
+def test_npe2pm_fixture(pytester: pytest.Pytester, case):
+    """Make sure that our make_napari_viewer plugin works."""
+
+    # create a temporary pytest test file
+    pytester.makepyfile(case)
+    pytester.runpytest().assert_outcomes(passed=1)


### PR DESCRIPTION
This makes the pattern that napari is using for testing available to anyone as a pytest fixture named `npe2pm`.

~(need to add tests)~