### PR TITLE
Add npe1_shim field to schema

### DIFF
--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -81,13 +81,14 @@ class NPE1Adapter(PluginManifest):
         self._dist = dist
 
     def __getattribute__(self, __name: str):
-        if __name == "contributions" and not self._is_loaded:
+        if __name == "contributions":
             self._load_contributions()
         return super().__getattribute__(__name)
 
     def _load_contributions(self, save=True) -> None:
         """import and inspect package contributions."""
-
+        if self._is_loaded:
+            return
         self._is_loaded = True  # if we fail once, we still don't try again.
         if self._cache_path().exists() and not os.getenv(NPE2_NOCACHE):
             mf = PluginManifest.from_file(self._cache_path())

--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -75,7 +75,9 @@ class NPE1Adapter(PluginManifest):
     def __init__(self, dist: metadata.Distribution):
         """_summary_"""
         meta = PackageMetadata.from_dist_metadata(dist.metadata)
-        super().__init__(name=dist.metadata["Name"], package_metadata=meta)
+        super().__init__(
+            name=dist.metadata["Name"], package_metadata=meta, npe1_shim=True
+        )
         self._dist = dist
 
     def __getattribute__(self, __name: str):
@@ -83,7 +85,7 @@ class NPE1Adapter(PluginManifest):
             self._load_contributions()
         return super().__getattribute__(__name)
 
-    def _load_contributions(self) -> None:
+    def _load_contributions(self, save=True) -> None:
         """import and inspect package contributions."""
 
         self._is_loaded = True  # if we fail once, we still don't try again.
@@ -106,7 +108,7 @@ class NPE1Adapter(PluginManifest):
             self.contributions = mf.contributions
             logger.debug("%r npe1 adapter imported", self.name)
 
-        if not _is_editable_install(self._dist):
+        if save and not _is_editable_install(self._dist):
             self._save_to_cache()
 
     def _save_to_cache(self):
@@ -117,6 +119,10 @@ class NPE1Adapter(PluginManifest):
     def _cache_path(self) -> Path:
         """Return cache path for manifest corresponding to distribution."""
         return _cached_adapter_path(self.name, self.package_version or "")
+
+    def yaml(self, **kwargs) -> str:
+        self._load_contributions(save=False)
+        return super().yaml(**kwargs)
 
 
 def _cached_adapter_path(name: str, version: str) -> Path:

--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -120,9 +120,9 @@ class NPE1Adapter(PluginManifest):
         """Return cache path for manifest corresponding to distribution."""
         return _cached_adapter_path(self.name, self.package_version or "")
 
-    def yaml(self, **kwargs) -> str:
+    def _serialized_data(self, **kwargs):
         self._load_contributions(save=False)
-        return super().yaml(**kwargs)
+        return super()._serialized_data(**kwargs)
 
 
 def _cached_adapter_path(name: str, version: str) -> Path:

--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -122,7 +122,8 @@ class NPE1Adapter(PluginManifest):
         return _cached_adapter_path(self.name, self.package_version or "")
 
     def _serialized_data(self, **kwargs):
-        self._load_contributions(save=False)
+        if not self._is_loaded:
+            self._load_contributions(save=False)
         return super()._serialized_data(**kwargs)
 
 

--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -122,7 +122,7 @@ class NPE1Adapter(PluginManifest):
         return _cached_adapter_path(self.name, self.package_version or "")
 
     def _serialized_data(self, **kwargs):
-        if not self._is_loaded:
+        if not self._is_loaded:  # pragma: no cover
             self._load_contributions(save=False)
         return super()._serialized_data(**kwargs)
 

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -126,6 +126,12 @@ class PluginManifest(ImportExportModel):
         exclude=True,
     )
 
+    npe1_shim: bool = Field(
+        False,
+        description="Whether this manifest was created as a shim for an npe1 plugin.",
+        hide_docs=True,
+    )
+
     def __init__(self, **data):
         super().__init__(**data)
         if self.package_metadata is None and self.name:


### PR DESCRIPTION
This adds a new top level `npe1_shim` field to the schema, which will make it possible to determine whether a serialized manifest represents a shimmed npe1 plugin or not.

This also makes sure that all shim manifests have their contributions loaded before serialization 

cc @DragaDoncila 