### PR TITLE
Fail silently when caching throws OSError

### DIFF
--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import site
@@ -110,12 +111,8 @@ class NPE1Adapter(PluginManifest):
             logger.debug("%r npe1 adapter imported", self.name)
 
         if save and not _is_editable_install(self._dist):
-            try:
+            with contextlib.suppress(OSError):
                 self._save_to_cache()
-            # could throw error on read only file system e.g. for napari hub,
-            # but we fail silently as caching is just convenience
-            except OSError:
-                pass
 
     def _save_to_cache(self):
         cache_path = self._cache_path()

--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -110,7 +110,12 @@ class NPE1Adapter(PluginManifest):
             logger.debug("%r npe1 adapter imported", self.name)
 
         if save and not _is_editable_install(self._dist):
-            self._save_to_cache()
+            try:
+                self._save_to_cache()
+            # could throw error on read only file system e.g. for napari hub,
+            # but we fail silently as caching is just convenience
+            except OSError:
+                pass
 
     def _save_to_cache(self):
         cache_path = self._cache_path()

--- a/tests/test_npe1_adapter.py
+++ b/tests/test_npe1_adapter.py
@@ -171,3 +171,15 @@ def test_adapter_error_on_import():
         with patch.object(_npe1_adapter, "manifest_from_npe1", wraps=err):
             adapter.contributions
     assert "Error importing contributions for" in str(record[0])
+
+def test_adapter_cache_fail(uses_npe1_plugin, mock_cache):
+    pm = PluginManager()
+    pm.discover(include_npe1=True)
+    mf = pm.get_manifest("npe1-plugin")
+
+    def err(obj):
+        raise OSError("Can't cache")
+
+    with patch.object(_npe1_adapter.NPE1Adapter, '_save_to_cache', err):
+        # shouldn't reraise the error
+        mf.contributions


### PR DESCRIPTION
Saving to cache with the current `cache_path` could (rarely) throw an `OSError` if the user didn't have permission to write to `/home`. We have run into this on the napari hub when working in a Docker image that only allows us to write to `/tmp`.

Since caching is just a convenience, this PR catches `OSError` on caching and fails silently.