### PR TITLE
Add `npe2 fetch` command to cli to fetch remote manifests

### DIFF
--- a/.github/workflows/test_all_plugins.yml
+++ b/.github/workflows/test_all_plugins.yml
@@ -42,29 +42,6 @@ jobs:
           miniforge-version: latest
           use-mamba: true
 
-      - id: check_conda
-        run: echo ::set-output name=status::$(curl -s -o /dev/null -w '%{http_code}' 'https://api.anaconda.org/package/conda-forge/${{ matrix.plugin }}')
-
-      # for now, until clesperanto is on conda and can declare it itself
-      - name: openCL deps
-        if: matrix.plugin == 'napari-pyclesperanto-assistant' && steps.check_conda.outputs.status != '200'
-        run: mamba install pyopencl oclgrind
-
-      # these plugins offer napari functionality
-      # but also work in the absence of napari... so probably don't want
-      # to add napari to their deps.
-      - name: install napari
-        if: matrix.plugin == "RedLionfish" || matrix.plugin == "smo"
-        run: mamba install napari
-
-      - name: Install ${{ matrix.plugin }} from conda
-        if: steps.check_conda.outputs.status == '200'
-        run: mamba install ${{ matrix.plugin }} pyqt
-
-      - name: Install ${{ matrix.plugin }} from pip
-        if: steps.check_conda.outputs.status != '200'
-        run: pip install ${{ matrix.plugin }} pyqt5
-
       - name: Install npe2
         run: pip install -e .[testing]
 

--- a/npe2/__init__.py
+++ b/npe2/__init__.py
@@ -6,19 +6,20 @@ __author__ = "Talley Lambert"
 __email__ = "talley.lambert@gmail.com"
 
 from ._dynamic_plugin import DynamicPlugin
+from ._fetch import fetch_manifest
 from ._plugin_manager import PluginContext, PluginManager
 from .io_utils import read, read_get_reader, write, write_get_writer
 from .manifest import PackageMetadata, PluginManifest
 
 __all__ = [
     "DynamicPlugin",
-    "PluginManifest",
-    "PluginManager",
-    "PluginContext",
+    "fetch_manifest",
     "PackageMetadata",
-    "write",
-    "read",
+    "PluginContext",
+    "PluginManager",
+    "PluginManifest",
     "read_get_reader",
-    "write",
+    "read",
     "write_get_writer",
+    "write",
 ]

--- a/npe2/_fetch.py
+++ b/npe2/_fetch.py
@@ -229,6 +229,7 @@ def _fetch_npe1_manifest(package: str, version: Optional[str] = None) -> PluginM
                 warnings.filterwarnings(
                     "error", message="Error importing contributions"
                 )
+                warnings.filterwarnings("ignore", message="Found a multi-layer writer")
                 mf._load_contributions(save=False)
         return mf
 

--- a/npe2/_fetch.py
+++ b/npe2/_fetch.py
@@ -130,7 +130,13 @@ def fetch_manifest(package: str, version: Optional[str] = None) -> PluginManifes
                 # PathDistribution.locate_file to get the file.
                 if ep.group == NPE2_ENTRY_POINT:
                     logger.debug("pypi wheel has npe2 entry point.")
-                    mf_file = dist.locate_file(Path(ep.module) / ep.attr)
+                    # python 3.8 fallbacks
+                    match = ep.pattern.match(ep.value)
+                    assert match
+                    module: str = match.groupdict()["module"]
+                    attr: str = match.groupdict()["attr"]
+
+                    mf_file = dist.locate_file(Path(module) / attr)
                     mf = PluginManifest.from_file(str(mf_file))
                     # manually add the package metadata from our distribution object.
                     mf.package_metadata = PackageMetadata.from_dist_metadata(

--- a/npe2/_fetch.py
+++ b/npe2/_fetch.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import site
+import sys
+import tempfile
+import warnings
+from contextlib import contextmanager
+from functools import lru_cache
+from importlib import metadata
+from io import BytesIO
+from logging import getLogger
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from urllib.request import urlopen
+from zipfile import ZipFile
+
+from build.env import IsolatedEnvBuilder
+
+if TYPE_CHECKING:
+    import build.env
+
+    from npe2.manifest.schema import PluginManifest
+
+logger = getLogger(__name__)
+
+
+def get_pypi_url(
+    name: str, version: Optional[str] = None, packagetype: Optional[str] = None
+) -> str:
+    """Get URL for a package on PyPI.
+
+    Parameters
+    ----------
+    name : str
+        package name
+    version : str, optional
+        package version, by default, latest version.
+    packagetype : str, optional
+        one of 'sdist', 'bdist_wheel', by default 'bdist_wheel' will be tried first,
+        then 'sdist'
+
+    Returns
+    -------
+    str
+        URL to download the package.
+
+    Raises
+    ------
+    ValueError
+        If packagetype is not one of 'sdist', 'bdist_wheel', or if version is specified
+        and does not match any available version.
+    KeyError
+        If packagetype is specified and no package of that type is available.
+    """
+    if packagetype not in {"sdist", "bdist_wheel", None}:
+        raise ValueError(
+            f"Invalid packagetype: {packagetype}, must be one of sdist, bdist_wheel"
+        )
+
+    with urlopen(f"https://pypi.org/pypi/{name}/json") as f:
+        data = json.load(f)
+
+    if version:
+        version = version.lstrip("v")
+        if version not in data["releases"]:
+            raise ValueError(f"{name} does not have version {version}")
+        _releases: List[dict] = data["releases"][version]
+    else:
+        _releases = data["urls"]
+
+    releases = {d.get("packagetype"): d for d in _releases}
+    if packagetype:
+        if packagetype not in releases:
+            version = version or "latest"
+            raise KeyError(f'No {packagetype} releases found for version "{version}"')
+        return releases[packagetype]["url"]
+    return (releases.get("bdist_wheel") or releases["sdist"])["url"]
+
+
+@contextmanager
+def _tmp_pypi_wheel_download(
+    name: str, version: Optional[str] = None
+) -> Iterator[Path]:
+    url = get_pypi_url(name, version=version, packagetype="bdist_wheel")
+    logger.debug(f"downloading wheel for {name} {version or ''}")
+    with tempfile.TemporaryDirectory() as td, urlopen(url) as f:
+        with ZipFile(BytesIO(f.read())) as zf:
+            zf.extractall(td)
+            yield Path(td)
+
+
+def fetch_manifest(package: str, version: Optional[str] = None) -> PluginManifest:
+    """Fetch a manifest for a pip specifier (package name, possibly with version).
+
+    Parameters
+    ----------
+    package : str
+        package name
+    version : Optional[str]
+        package version, by default, latest version.
+
+    Returns
+    -------
+    PluginManifest
+        Plugin manifest for package `specifier`.
+    """
+
+    from npe2 import PluginManifest
+    from npe2.manifest import PackageMetadata
+
+    is_npe1 = False
+
+    # first just grab the wheel from pypi with no dependencies
+    with _tmp_pypi_wheel_download(package, version) as td:
+        # create a PathDistribution from the dist-info directory in the wheel
+        dist = metadata.PathDistribution(next(Path(td).glob("*.dist-info")))
+
+        for ep in dist.entry_points:
+            # if we find an npe2 entry point, we can just use
+            # PathDistribution.locate_file to get the file.
+            if ep.group == "napari.manifest":
+                logger.debug("pypi wheel has npe2 entry point.")
+                mf_file = dist.locate_file(Path(ep.module) / ep.attr)
+                mf = PluginManifest.from_file(str(mf_file))
+                # manually add the package metadata from our distribution object.
+                mf.package_metadata = PackageMetadata.from_dist_metadata(dist.metadata)
+                return mf
+            elif ep.group == "napari.plugin":
+                is_npe1 = True
+
+    if not is_npe1:
+        raise ValueError(f"{package} had no napari entry points.")
+
+    logger.debug("falling back to npe1")
+    return _fetch_npe1_manifest(package, version=version)
+
+
+@contextmanager
+def isolated_plugin_env(
+    package: str,
+    version: Optional[str] = None,
+    validate_npe1_imports: bool = True,
+    install_napari_if_necessary: bool = True,
+) -> Iterator[build.env.IsolatedEnv]:
+    """Isolated env context with a plugin installed.
+
+    The site-packages folder of the env is added to sys.path within the context.
+
+    Parameters
+    ----------
+    package : str
+        package name
+    version : Optional[str]
+        package version, by default, latest version.
+    validate_npe1_imports: bool
+        Whether to try to import an npe1 plugin's entry points. by default True.
+    install_napari_if_necessary: bool
+        If `validate_npe1_imports` is True, whether to install napari if the import
+        fails.  (It's not uncommon for plugins to fail to specify napari as a
+        dependency.  Othertimes, they simply need a qt backend.).  by default True.
+
+    Yields
+    ------
+    build.env.IsolatedEnv
+        env object that has an `install` method.
+    """
+    with IsolatedEnvBuilder() as env:
+        # install the package
+        pkg = f"{package}=={version}" if version else package
+        logger.debug(f"installing {pkg} into virtual env")
+        env.install([pkg])
+
+        # temporarily add env site packages to path
+        prefixes = [getattr(env, "path")]  # noqa
+        if not (site_pkgs := site.getsitepackages(prefixes=prefixes)):
+            raise ValueError("No site-packages found")
+        sys.path.insert(0, site_pkgs[0])
+        try:
+            if validate_npe1_imports:
+                dist = metadata.distribution(package)
+
+                npe1_eps: List[metadata.EntryPoint] = [
+                    ep for ep in dist.entry_points if ep.group == "napari.plugin"
+                ]
+                for ep in npe1_eps:
+                    try:
+                        ep.load()
+                    except ImportError:
+                        # if loading contributions fails, it can very often be fixed
+                        # by installing `napari[all]` into the environment
+                        if install_napari_if_necessary:
+                            env.install(["napari[all]"])
+                            # force reloading of qtpy
+                            sys.modules.pop("qtpy", None)
+                            ep.load()
+                        else:
+                            raise
+            yield env
+        finally:
+            # cleanup sys.path
+            sys.path.pop(0)
+
+
+def _fetch_npe1_manifest(package: str, version: Optional[str] = None) -> PluginManifest:
+    """Fetch manifest for npe1 plugin in an isolated environment."""
+    from npe2.manifest._npe1_adapter import NPE1Adapter
+    from npe2.manifest.schema import PluginManifest
+
+    # create an isolated env in which to install npe1 plugin
+    with isolated_plugin_env(package, version):
+        mf = PluginManifest.from_distribution(package)
+        if isinstance(mf, NPE1Adapter):
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "error", message="Error importing contributions"
+                )
+                mf._load_contributions(save=False)
+        return mf
+
+
+@lru_cache
+def get_all_plugins() -> Dict[str, str]:
+    """Return {name: latest_version} for all plugins on the hub."""
+    with urlopen("https://api.napari-hub.org/plugins") as r:
+        return json.load(r)
+
+
+@lru_cache
+def get_plugin_info(plugin: str) -> Dict[str, Any]:
+    """Return hub information for a specific plugin."""
+    with urlopen(f"https://api.napari-hub.org/plugins/{plugin}") as r:
+        return json.load(r)

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -88,7 +88,7 @@ def _check_output(output: Path) -> Format:
             f"Invalid output extension {output.suffix!r}. Must be one of: "
             + ", ".join(Format._member_names_)
         )
-        raise typer.Exit()
+        raise typer.Exit(1)
     return Format(output.suffix.lstrip("."))
 
 
@@ -117,15 +117,13 @@ def parse(
     ),
 ):
     """Show parsed manifest as yaml."""
-    if output:
-        format = _check_output(output)
-
+    fmt = _check_output(output) if output else format
     pm = PluginManifest._from_package_or_name(name)
-    manifest_string = getattr(pm, format.value)(indent=indent)
+    manifest_string = getattr(pm, fmt.value)(indent=indent)
     if output:
         output.write_text(manifest_string)
     else:
-        _pprint_formatted(manifest_string, format)
+        _pprint_formatted(manifest_string, fmt)
 
 
 @app.command()
@@ -164,20 +162,18 @@ def fetch(
     """
     from npe2._fetch import fetch_manifest
 
-    if output:
-        format = _check_output(output)
-
+    fmt = _check_output(output) if output else format
     kwargs: dict = {"indent": indent}
     if include_package_meta:
         kwargs["exclude"] = set()
 
     mf = fetch_manifest(name, version=version)
-    manifest_string = getattr(mf, format.value)(**kwargs)
+    manifest_string = getattr(mf, fmt.value)(**kwargs)
 
     if output:
         output.write_text(manifest_string)
     else:
-        _pprint_formatted(manifest_string, format)
+        _pprint_formatted(manifest_string, fmt)
 
 
 @app.command()

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -81,6 +81,31 @@ def parse(name: str):
 
 
 @app.command()
+def fetch(
+    name: str,
+    version: Optional[str] = None,
+    include_package_meta: Optional[bool] = typer.Option(
+        False,
+        "-m",
+        "--include-package-meta",
+        help="Include package metadata in the manifest.",
+    ),
+):
+    """Fetch manifest from remote package.
+
+    If an npe2 plugin is detected, the manifest is returned directly, otherwise
+    it will be installed into a temporary directory, imported, and discovered.
+    """
+    from npe2.manifest.utils import fetch_manifest
+
+    mf = fetch_manifest(name, version=version)
+    kwargs: dict = {"indent": 2}
+    # if include_package_meta:
+    #     kwargs["exclude"] = set()
+    _pprint_yaml(mf.json(**kwargs))
+
+
+@app.command()
 def convert(
     path: Path = typer.Argument(
         ...,

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -100,9 +100,9 @@ def fetch(
 
     mf = fetch_manifest(name, version=version)
     kwargs: dict = {"indent": 2}
-    # if include_package_meta:
-    #     kwargs["exclude"] = set()
-    _pprint_yaml(mf.json(**kwargs))
+    if include_package_meta:
+        kwargs["exclude"] = set()
+    _pprint_yaml(mf.yaml(**kwargs))
 
 
 @app.command()

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -96,7 +96,7 @@ def fetch(
     If an npe2 plugin is detected, the manifest is returned directly, otherwise
     it will be installed into a temporary directory, imported, and discovered.
     """
-    from npe2.manifest.utils import fetch_manifest
+    from npe2._fetch import fetch_manifest
 
     mf = fetch_manifest(name, version=version)
     kwargs: dict = {"indent": 2}

--- a/npe2/manifest/_npe1_adapter.py
+++ b/npe2/manifest/_npe1_adapter.py
@@ -75,17 +75,20 @@ class NPE1Adapter(PluginManifest):
     def __init__(self, dist: metadata.Distribution):
         """_summary_"""
         meta = PackageMetadata.from_dist_metadata(dist.metadata)
-        super().__init__(name=dist.metadata["Name"], package_metadata=meta)
+        super().__init__(
+            name=dist.metadata["Name"], package_metadata=meta, npe1_shim=True
+        )
         self._dist = dist
 
     def __getattribute__(self, __name: str):
-        if __name == "contributions" and not self._is_loaded:
+        if __name == "contributions":
             self._load_contributions()
         return super().__getattribute__(__name)
 
-    def _load_contributions(self) -> None:
+    def _load_contributions(self, save=True) -> None:
         """import and inspect package contributions."""
-
+        if self._is_loaded:
+            return
         self._is_loaded = True  # if we fail once, we still don't try again.
         if self._cache_path().exists() and not os.getenv(NPE2_NOCACHE):
             mf = PluginManifest.from_file(self._cache_path())
@@ -106,7 +109,7 @@ class NPE1Adapter(PluginManifest):
             self.contributions = mf.contributions
             logger.debug("%r npe1 adapter imported", self.name)
 
-        if not _is_editable_install(self._dist):
+        if save and not _is_editable_install(self._dist):
             self._save_to_cache()
 
     def _save_to_cache(self):
@@ -117,6 +120,11 @@ class NPE1Adapter(PluginManifest):
     def _cache_path(self) -> Path:
         """Return cache path for manifest corresponding to distribution."""
         return _cached_adapter_path(self.name, self.package_version or "")
+
+    def _serialized_data(self, **kwargs):
+        if not self._is_loaded:  # pragma: no cover
+            self._load_contributions(save=False)
+        return super()._serialized_data(**kwargs)
 
 
 def _cached_adapter_path(name: str, version: str) -> Path:

--- a/npe2/manifest/_package_metadata.py
+++ b/npe2/manifest/_package_metadata.py
@@ -192,8 +192,7 @@ class PackageMetadata(BaseModel):
         """Accepts importlib.metadata.Distribution.metadata"""
         manys = [f.name for f in cls.__fields__.values() if f.shape == SHAPE_LIST]
         d: Dict[str, Union[str, List[str]]] = {}
-        for key in meta:
-            value = meta[key]
+        for key, value in meta.items():
             key = _norm(key)
             if key in manys:
                 d.setdefault(key, []).append(value)  # type: ignore

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -123,7 +123,6 @@ class PluginManifest(ImportExportModel):
         "For normal (non-dynamic) plugins, this data will come from the package's "
         "setup.cfg",
         hide_docs=True,
-        # exclude=True,
     )
 
     npe1_shim: bool = Field(

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -123,7 +123,7 @@ class PluginManifest(ImportExportModel):
         "For normal (non-dynamic) plugins, this data will come from the package's "
         "setup.cfg",
         hide_docs=True,
-        exclude=True,
+        # exclude=True,
     )
 
     npe1_shim: bool = Field(

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -126,6 +126,12 @@ class PluginManifest(ImportExportModel):
         exclude=True,
     )
 
+    npe1_shim: bool = Field(
+        False,
+        description="Whether this manifest was created as a shim for an npe1 plugin.",
+        hide_docs=True,
+    )
+
     def __init__(self, **data):
         super().__init__(**data)
         if self.package_metadata is None and self.name:

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -12,7 +12,6 @@ from functools import lru_cache, total_ordering
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from subprocess import run
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -35,7 +34,6 @@ from build.env import IsolatedEnvBuilder
 
 if TYPE_CHECKING:
     from npe2.manifest.schema import PluginManifest
-    from subprocess import _FILE
 
 from ..types import PythonName
 
@@ -374,35 +372,9 @@ def get_pypi_url(
     if packagetype:
         if packagetype not in releases:
             version = version or "latest"
-            raise KeyError('No {packagetype} releases found for version "{version}"')
+            raise KeyError(f'No {packagetype} releases found for version "{version}"')
         return releases[packagetype]["url"]
     return (releases.get("bdist_wheel") or releases["sdist"])["url"]
-
-
-@contextmanager
-def tmp_pip_install(
-    package: str,
-    version: Optional[str] = None,
-    stdout: _FILE = None,
-    extra_packages: Sequence[str] = (),
-):
-    """Context in which a pip specifier is installed and added to sys.path.
-
-    Parameters
-    ----------
-    package : str
-        pypi package name
-    version : str, optional
-        optional package version, by default, latest version.
-    stdout : subprocess._FILE
-        stdout for pip install, by default DEVNULL
-    """
-    with tempfile.TemporaryDirectory() as td:
-        pkg = f"{package}=={version}" if version else package
-        cmd = ["pip", "install", "--target", td, pkg] + list(extra_packages)
-        run(cmd, check=True, stdout=stdout)
-        sys.path.insert(0, td)
-        yield td
 
 
 @contextmanager

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -1,26 +1,15 @@
 from __future__ import annotations
 
-import json
 import re
-import site
-import sys
-import tempfile
-import warnings
-from contextlib import contextmanager
 from dataclasses import dataclass
-from functools import lru_cache, total_ordering
-from importlib import import_module, metadata
-from io import BytesIO
-from logging import getLogger
-from pathlib import Path
+from functools import total_ordering
+from importlib import import_module
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Generic,
-    Iterator,
-    List,
     Optional,
     Sequence,
     SupportsInt,
@@ -28,16 +17,12 @@ from typing import (
     TypeVar,
     Union,
 )
-from urllib.request import urlopen
-from zipfile import ZipFile
 
-from build.env import IsolatedEnvBuilder
+from ..types import PythonName
 
 if TYPE_CHECKING:
     from npe2.manifest.schema import PluginManifest
-    import build.env
 
-from ..types import PythonName
 
 if TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -50,9 +35,6 @@ if TYPE_CHECKING:
 
         def get_callable(self, _registry: Optional[CommandRegistry] = None):
             ...
-
-
-logger = getLogger(__name__)
 
 
 def v1_to_v2(path):
@@ -248,7 +230,6 @@ def _import_npe1_shim(shim_name: str) -> Any:
 
 
 def import_python_name(python_name: Union[PythonName, str]) -> Any:
-
     from . import _validators
 
     if python_name.startswith(SHIM_NAME_PREFIX):
@@ -319,233 +300,3 @@ def merge_contributions(contribs: Sequence[Optional[ContributionPoints]]) -> dic
                             item["command"] = item["command"] + f"_{n + 2}"
             out = deep_update(out, c)
     return out
-
-
-def get_pypi_url(
-    name: str, version: Optional[str] = None, packagetype: Optional[str] = None
-) -> str:
-    """Get URL for a package on PyPI.
-
-    Parameters
-    ----------
-    name : str
-        package name
-    version : str, optional
-        package version, by default, latest version.
-    packagetype : str, optional
-        one of 'sdist', 'bdist_wheel', by default 'bdist_wheel' will be tried first,
-        then 'sdist'
-
-    Returns
-    -------
-    str
-        URL to download the package.
-
-    Raises
-    ------
-    ValueError
-        If packagetype is not one of 'sdist', 'bdist_wheel', or if version is specified
-        and does not match any available version.
-    KeyError
-        If packagetype is specified and no package of that type is available.
-    """
-    if packagetype not in {"sdist", "bdist_wheel", None}:
-        raise ValueError(
-            f"Invalid packagetype: {packagetype}, must be one of sdist, bdist_wheel"
-        )
-
-    with urlopen(f"https://pypi.org/pypi/{name}/json") as f:
-        data = json.load(f)
-
-    if version:
-        version = version.lstrip("v")
-        if version not in data["releases"]:
-            raise ValueError(f"{name} does not have version {version}")
-        _releases: List[dict] = data["releases"][version]
-    else:
-        _releases = data["urls"]
-
-    releases = {d.get("packagetype"): d for d in _releases}
-    if packagetype:
-        if packagetype not in releases:
-            version = version or "latest"
-            raise KeyError(f'No {packagetype} releases found for version "{version}"')
-        return releases[packagetype]["url"]
-    return (releases.get("bdist_wheel") or releases["sdist"])["url"]
-
-
-@contextmanager
-def _tmp_pypi_wheel_download(
-    name: str, version: Optional[str] = None
-) -> Iterator[Path]:
-    url = get_pypi_url(name, version=version, packagetype="bdist_wheel")
-    logger.debug(f"downloading wheel for {name} {version or ''}")
-    with tempfile.TemporaryDirectory() as td, urlopen(url) as f:
-        with ZipFile(BytesIO(f.read())) as zf:
-            zf.extractall(td)
-            yield Path(td)
-
-
-def fetch_manifest(package: str, version: Optional[str] = None) -> PluginManifest:
-    """Fetch a manifest for a pip specifier (package name, possibly with version).
-
-    Parameters
-    ----------
-    package : str
-        package name
-    version : str, optional
-        package version, by default, latest version.
-
-    Returns
-    -------
-    PluginManifest
-        Plugin manifest for package `specifier`.
-    """
-
-    from npe2 import PluginManifest
-    from npe2.manifest import PackageMetadata
-
-    is_npe1 = False
-
-    # first just grab the wheel from pypi with no dependencies
-    with _tmp_pypi_wheel_download(package, version) as td:
-        # create a PathDistribution from the dist-info directory in the wheel
-        dist = metadata.PathDistribution(next(Path(td).glob("*.dist-info")))
-
-        for ep in dist.entry_points:
-            # if we find an npe2 entry point, we can just use
-            # PathDistribution.locate_file to get the file.
-            if ep.group == "napari.manifest":
-                logger.debug("pypi wheel has npe2 entry point.")
-                mf_file = dist.locate_file(Path(ep.module) / ep.attr)
-                mf = PluginManifest.from_file(str(mf_file))
-                # manually add the package metadata from our distribution object.
-                mf.package_metadata = PackageMetadata.from_dist_metadata(dist.metadata)
-                return mf
-            elif ep.group == "napari.plugin":
-                is_npe1 = True
-
-    if not is_npe1:
-        raise ValueError(f"{package} had no napari entry points.")
-
-    logger.debug("falling back to npe1")
-    return fetch_npe1_manifest(package, version=version)
-
-
-@lru_cache
-def get_all_plugins() -> Dict[str, str]:
-    with urlopen("https://api.napari-hub.org/plugins") as r:
-        return json.load(r)
-
-
-@lru_cache
-def get_plugin_info(plugin: str):
-    with urlopen(f"https://api.napari-hub.org/plugins/{plugin}") as r:
-        return json.load(r)
-
-
-def _try_load_contributions(mf, raising=False):
-    from npe2.manifest._npe1_adapter import NPE1Adapter
-
-    if not isinstance(mf, NPE1Adapter):
-        return True
-
-    mf._is_loaded = False
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "error",
-                message="Error importing contributions",
-                category=UserWarning,
-            )
-            mf._load_contributions(save=False)
-            return True
-    except Exception as e:
-        if raising:
-            raise ValueError(
-                f"Unable to load contributions for npe1 plugin {mf.name}: {e}"
-            ) from e
-
-        return False
-
-
-@contextmanager
-def isolated_plugin_env(
-    package: str,
-    version: Optional[str] = None,
-    validate_ep_imports: bool = True,
-    install_napari_if_necessary: bool = True,
-) -> Iterator[build.env.IsolatedEnv]:
-    """Isolated env context with a plugin installed.
-
-    The site-packages folder of the env is added to sys.path within the context.
-
-    Parameters
-    ----------
-    package : str
-        package name
-    version : str, optional
-        package version, by default, latest version.
-
-    Yields
-    ------
-    build.env.IsolatedEnv
-        env object that has an `install` method.
-    """
-    print("building isolated env")
-    with IsolatedEnvBuilder() as env:
-        # install the package
-        pkg = f"{package}=={version}" if version else package
-        logger.debug(f"installing {pkg} into virtual env")
-        env.install([pkg])
-
-        # temporarily add env site packages to path
-        prefixes = [getattr(env, "path")]  # noqa
-        if not (site_pkgs := site.getsitepackages(prefixes=prefixes)):
-            raise ValueError("No site-packages found")
-        sys.path.insert(0, site_pkgs[0])
-        try:
-            if validate_ep_imports:
-                dist = metadata.distribution(package)
-
-                npe1_eps: List[metadata.EntryPoint] = [
-                    ep for ep in dist.entry_points if ep.group == "napari.plugin"
-                ]
-                for ep in npe1_eps:
-                    try:
-                        ep.load()
-                    except ImportError:
-                        # if loading contributions fails, it can very often be fixed
-                        # by installing `napari[all]` into the environment
-                        if install_napari_if_necessary:
-                            env.install(["napari[all]"])
-                            # force reloading of qtpy
-                            sys.modules.pop("qtpy", None)
-                            ep.load()
-                        else:
-                            raise
-            yield env
-        finally:
-            # cleanup sys.path
-            sys.path.pop(0)
-
-
-def fetch_npe1_manifest(package: str, version: Optional[str] = None) -> PluginManifest:
-    from npe2.manifest._npe1_adapter import NPE1Adapter
-    from npe2.manifest.schema import PluginManifest
-
-    # create an isolated env in which to install npe1 plugin
-    with isolated_plugin_env(package, version):
-        mf = PluginManifest.from_distribution(package)
-        if isinstance(mf, NPE1Adapter):
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "error", message="Error importing contributions"
-                )
-                mf._load_contributions(save=False)
-        return mf
-
-
-if __name__ == "__main__":
-    mf = fetch_npe1_manifest("napari-clusters-plotter")
-    print(mf.yaml())

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages = find:
 install_requires =
     PyYAML
     appdirs
+    build
     magicgui>=0.3.3
     psygnal>=0.3.0
     pydantic

--- a/tests/test_all_plugins.py
+++ b/tests/test_all_plugins.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pytest
 
-PLUGIN = os.getenv("TEST_PACKAGE_NAME")
+PLUGIN: str = os.getenv("TEST_PACKAGE_NAME") or ""
 if not PLUGIN:
     pytest.skip("skipping plugin specific tests", allow_module_level=True)
 
@@ -49,3 +49,10 @@ def test_entry_points_importable(entry_points: List[metadata.EntryPoint]):
     for ep in entry_points:
         if ep.group == "napari.plugin":
             ep.load()
+
+
+@m
+def test_fetch():
+    import subprocess
+
+    subprocess.run(["npe2", "fetch", PLUGIN])

--- a/tests/test_all_plugins.py
+++ b/tests/test_all_plugins.py
@@ -22,7 +22,7 @@ def plugin_env():
         with isolated_plugin_env(PLUGIN) as env:
             yield env
     except CalledProcessError as e:
-        if "Failed building wheel" in e.output:
+        if "Failed building wheel" in str(e.output):
             yield None
 
 

--- a/tests/test_all_plugins.py
+++ b/tests/test_all_plugins.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from npe2 import PluginManifest
+from npe2._fetch import isolated_plugin_env
 from npe2.cli import app
-from npe2.manifest.utils import isolated_plugin_env
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,52 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from npe2 import fetch_manifest
+from npe2._fetch import (
+    _fetch_manifest_with_full_install,
+    get_all_plugins,
+    get_plugin_info,
+    get_pypi_url,
+)
+from npe2.manifest._npe1_adapter import NPE1Adapter
+
+
+def test_npe2_from_pypi_wheel():
+    mf = fetch_manifest("napari-omero")
+    assert mf.name == "napari-omero"
+    assert mf.contributions
+
+
+@pytest.mark.parametrize("version", [None, "0.1.0"])
+@pytest.mark.parametrize("packagetype", ["sdist", "bdist_wheel", None])
+def test_get_pypi_url(version, packagetype):
+    assert "npe2" in get_pypi_url("npe2", version=version, packagetype=packagetype)
+
+
+def test_from_pypi_wheel_bdist_missing():
+    error = KeyError("No bdist_wheel releases found")
+    p2 = patch("npe2._fetch.get_pypi_url", side_effect=error)
+    with patch("npe2._fetch._fetch_manifest_with_full_install") as mock_fetch, p2:
+        fetch_manifest("my-package")
+    mock_fetch.assert_called_once_with("my-package", version=None)
+
+
+@pytest.mark.skipif(not os.getenv("CI"), reason="slow, only run on CI")
+def test_fetch_manifest_with_full_install():
+    # TODO: slowest of the tests ... would be nice to provide a local mock
+    mf = _fetch_manifest_with_full_install("napari-ndtiffs")
+    assert isinstance(mf, NPE1Adapter)
+    assert mf.name == "napari-ndtiffs"
+    assert mf.contributions
+
+
+def test_get_all_plugins():
+    plugins = get_all_plugins()
+    assert "napari-svg" in plugins
+
+
+def test_get_plugin_info():
+    info = get_plugin_info("napari-svg")
+    assert info["name"] == "napari-svg"

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -6,8 +6,8 @@ import pytest
 from npe2 import fetch_manifest
 from npe2._fetch import (
     _fetch_manifest_with_full_install,
-    get_all_plugins,
-    get_plugin_info,
+    get_hub_plugin,
+    get_hub_plugins,
     get_pypi_url,
 )
 from npe2.manifest._npe1_adapter import NPE1Adapter
@@ -42,11 +42,11 @@ def test_fetch_manifest_with_full_install():
     assert mf.contributions
 
 
-def test_get_all_plugins():
-    plugins = get_all_plugins()
+def test_get_hub_plugins():
+    plugins = get_hub_plugins()
     assert "napari-svg" in plugins
 
 
-def test_get_plugin_info():
-    info = get_plugin_info("napari-svg")
+def test_get_hub_plugin():
+    info = get_hub_plugin("napari-svg")
     assert info["name"] == "napari-svg"


### PR DESCRIPTION
~cc @DragaDoncila ... just a proof of principle at the moment... but working for a couple challenging ones, like `npe2 fetch napari-omero` (works because it doesn't try to install) and `npe2 fetch napari-clusters-plotter` (works because it creates a temporary install with `napari[all]` ... which is likely why many of the nometa group are failing)~

~The goal here is to essentially try the fastest, easiest, most direct methods first, then fall back to fully installing~

This adds a new `fetch` command to npe2 that will grab a manifest for any napari plugin listed on pypi.  This *includes* npe1 packges, which will be installed into a temporary isolated environment, imported, and indexed into an npe1 shim
```sh
╰─❯ npe2 fetch napari-omero
name: napari-omero
schema_version: 0.1.0
contributions:
  commands:
  - id: napari-omero.widget
    title: Open OMERO widget
    python_name: napari_omero.widgets.main:OMEROWidget
  - id: napari-omero.get_reader
    title: OMERO reader
    python_name: napari_omero.plugins._napari:napari_get_reader
  readers:
  - command: napari-omero.get_reader
    filename_patterns:
    - omero://*
  widgets:
  - command: napari-omero.widget
    display_name: OMERO Browser
```