### PR TITLE
Allow `@implements` in comments, and prevent runtime-arg checking by default

### DIFF
--- a/npe2/implements.py
+++ b/npe2/implements.py
@@ -9,6 +9,17 @@ from pydantic import BaseModel
 
 from .manifest import contributions
 
+__all__ = [
+    "on_activate",
+    "on_deactivate",
+    "PluginModuleVisitor",
+    "reader",
+    "sample_data_generator",
+    "visit",
+    "widget",
+    "writer",
+]
+
 T = TypeVar("T", bound=Callable[..., Any])
 _COMMAND_PARAMS = inspect.signature(contributions.CommandContribution).parameters
 

--- a/npe2/implements.pyi
+++ b/npe2/implements.pyi
@@ -17,6 +17,7 @@ def reader(
     title: str,
     filename_patterns: List[str],
     accepts_directories: bool = False,
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark a function as a reader contribution"""
 
@@ -27,6 +28,7 @@ def writer(
     layer_types: List[str],
     filename_extensions: List[str] = [],
     display_name: str = "",
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark function as a writer contribution"""
 
@@ -36,6 +38,7 @@ def widget(
     title: str,
     display_name: str,
     autogenerate: bool = False,
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark a function as a widget contribution"""
 
@@ -45,6 +48,7 @@ def sample_data_generator(
     title: str,
     key: str,
     display_name: str,
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark a function as a sample data generator contribution"""
 

--- a/tests/sample/_with_decorators.py
+++ b/tests/sample/_with_decorators.py
@@ -34,6 +34,7 @@ def get_reader(path: str):
     title="URL Reader",
     filename_patterns=["http://*", "https://*"],
     accepts_directories=False,
+    ensure_args_valid=True,
 )
 def url_reader(path: str):
     ...
@@ -90,3 +91,9 @@ def random_data():
 )
 def make_widget_from_function(x: int, threshold: int):
     ...
+
+
+# test that poorly contructed comments don't break things.
+# @npe2.implements.some_nonsense(
+#     print(1)
+# )

--- a/tests/sample/_with_decorators.py
+++ b/tests/sample/_with_decorators.py
@@ -55,12 +55,12 @@ def writer_function(path: str, layer_data: List[Tuple[Any, Dict, str]]) -> List[
     ...
 
 
-@implements.writer(
-    id="my_single_writer",
-    title="My single-layer Writer",
-    filename_extensions=["*.xyz"],
-    layer_types=["labels"],
-)
+# @npe2.implements.writer(
+#     id="my_single_writer",
+#     title="My single-layer Writer",
+#     filename_extensions=["*.xyz"],
+#     layer_types=["labels"],
+# )
 def writer_function_single(path: str, layer_data: Any, meta: Dict) -> List[str]:
     ...
 


### PR DESCRIPTION
This PR adds two things to the `npe2.implements` decorators
 
1. Adds a safety measure with a new `ensure_args_valid = False` parameter to the decorators:

```
@npe2.implements.reader(
    id="url_reader",
    title="URL Reader",
    filename_patterns=["http://*", "https://*"],
    ensure_args_valid=True,
)
def url_reader(path: str):
    ...
```

by default, it is `False` ... meaning the decorators do essentially nothing at runtime.  This is a safety measure in case some plugin uses the decorator, and then eventually goes out of spec with the npe2 schema.  If npe2 is updated in the environment, the decorator will just do nothing.  Those errors can still be detected at compile time (when building the manifest), but they should _not_ error at runtime unless the plugin specifically requests it.

It also allows decorators **in comments** to be detected, meaning a plugin can use `npe2 compile` to build a manifest with **no** runtime impact or dependency on npe2 at all.  This should help to address comments about depending on npe2 in @nclack's https://github.com/napari/npe2/pull/75#pullrequestreview-1012855747
It looks like this:

```python
# No import needed!
# @npe2.implements.writer(
#     id="my_single_writer",
#     title="My single-layer Writer",
#     filename_extensions=["*.xyz"],
#     layer_types=["labels"],
# )
def writer_function_single(path: str, layer_data: Any, meta: Dict) -> List[str]:
    ...
```

the only restriction at the moment is that the decorator name _must_ use the fully qualified `npe2.implements.something`, rather than `@implements.something` or `@something`