### PR TITLE
Allow `@npe2.implements` in comments, avoiding any runtime dependency

### DIFF
--- a/npe2/implements.py
+++ b/npe2/implements.py
@@ -1,4 +1,5 @@
 import ast
+import contextlib
 import inspect
 from inspect import Parameter, Signature
 from pathlib import Path
@@ -92,14 +93,17 @@ def _build_decorator(contrib: Type[BaseModel]) -> Callable:
     # as attributes on the function being decorated.
     def _deco(**kwargs) -> Callable[[T], T]:
         def _store_attrs(func: T) -> T:
-            # assert we've satisfied the signature when the decorator is invoked
+            # If requested, assert that we've satisfied the signature when
+            # the decorator is invoked at runtime.
             # TODO: improve error message to provide context
             if kwargs.pop(CHECK_ARGS_PARAM, False):
                 signature.bind(**kwargs)
 
-            # store these attributes on the function
             # TODO: check if it's already there and assert the same id
-            setattr(func, f"_npe2_{contrib.__name__}", kwargs)
+            # store these attributes on the function
+            with contextlib.suppress(AttributeError):
+                setattr(func, f"_npe2_{contrib.__name__}", kwargs)
+
             # return the original decorated function
             return func
 

--- a/npe2/implements.py
+++ b/npe2/implements.py
@@ -9,6 +9,17 @@ from pydantic import BaseModel
 
 from .manifest import contributions
 
+__all__ = [
+    "on_activate",
+    "on_deactivate",
+    "PluginModuleVisitor",
+    "reader",
+    "sample_data_generator",
+    "visit",
+    "widget",
+    "writer",
+]
+
 T = TypeVar("T", bound=Callable[..., Any])
 _COMMAND_PARAMS = inspect.signature(contributions.CommandContribution).parameters
 

--- a/npe2/implements.pyi
+++ b/npe2/implements.pyi
@@ -17,6 +17,7 @@ def reader(
     title: str,
     filename_patterns: List[str],
     accepts_directories: bool = False,
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark a function as a reader contribution"""
 
@@ -27,6 +28,7 @@ def writer(
     layer_types: List[str],
     filename_extensions: List[str] = [],
     display_name: str = "",
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark function as a writer contribution"""
 
@@ -36,6 +38,7 @@ def widget(
     title: str,
     display_name: str,
     autogenerate: bool = False,
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark a function as a widget contribution"""
 
@@ -45,6 +48,7 @@ def sample_data_generator(
     title: str,
     key: str,
     display_name: str,
+    ensure_args_valid: bool = False,
 ) -> Callable[[T], T]:
     """Mark a function as a sample data generator contribution"""
 

--- a/tests/sample/_with_decorators.py
+++ b/tests/sample/_with_decorators.py
@@ -34,6 +34,7 @@ def get_reader(path: str):
     title="URL Reader",
     filename_patterns=["http://*", "https://*"],
     accepts_directories=False,
+    ensure_args_valid=True,
 )
 def url_reader(path: str):
     ...
@@ -90,3 +91,9 @@ def random_data():
 )
 def make_widget_from_function(x: int, threshold: int):
     ...
+
+
+# test that poorly contructed comments don't break things.
+# @npe2.implements.some_nonsense(
+#     print(1)
+# )

--- a/tests/sample/_with_decorators.py
+++ b/tests/sample/_with_decorators.py
@@ -55,12 +55,12 @@ def writer_function(path: str, layer_data: List[Tuple[Any, Dict, str]]) -> List[
     ...
 
 
-@implements.writer(
-    id="my_single_writer",
-    title="My single-layer Writer",
-    filename_extensions=["*.xyz"],
-    layer_types=["labels"],
-)
+# @npe2.implements.writer(
+#     id="my_single_writer",
+#     title="My single-layer Writer",
+#     filename_extensions=["*.xyz"],
+#     layer_types=["labels"],
+# )
 def writer_function_single(path: str, layer_data: Any, meta: Dict) -> List[str]:
     ...
 


### PR DESCRIPTION
(split out from #188)

This PR allows `npe2.implements` decorators **in comments** to be detected, meaning a plugin can use `npe2 compile` to build a manifest with **no** runtime impact or dependency on npe2 at all.  This should help to address comments about depending on npe2 in @nclack's https://github.com/napari/npe2/pull/75#pullrequestreview-1012855747
It looks like this:

```python
# No import needed!
# @npe2.implements.writer(
#     id="my_single_writer",
#     title="My single-layer Writer",
#     filename_extensions=["*.xyz"],
#     layer_types=["labels"],
# )
def writer_function_single(path: str, layer_data: Any, meta: Dict) -> List[str]:
    ...
```

the only restriction at the moment is that the decorator name _must_ use the fully qualified `npe2.implements.something`, rather than `@implements.something` or `@something`

note: this includes #188 

**edit**
an alternative to this strategy, for those who want *almost* zero runtime impact, but still want the benefits of type hinting in their IDE:

```python
if TYPE_CHECKING:
    from npe2 import implements
else:
    class Implements:
        def __getattr__(self, k) -> Any:
            def deco(*args, **kwargs):
                return lambda x: x
            return deco
    implements = Implements()

@implements.writer(
    id="write_single_image",
    title="Save image data with napari FooBar",
    layer_types=["image"],
    filename_extensions=[".npy"],
)
def write_single_image(path: str, data: Any, meta: dict):
    """Writes a single image layer"""
```

the little TYPE_CHECKING clause at the top would just be something that we document, and someone could use.  It requires more copy/pasting than the comments, and _might_ need to go in lots of modules?   but it's not a comment?