### PR TITLE
Remove typing-extensions imports

### DIFF
--- a/npe2/_dynamic_plugin.py
+++ b/npe2/_dynamic_plugin.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -14,7 +15,6 @@ from typing import (
 )
 
 from pydantic import BaseModel, ValidationError
-from typing_extensions import Literal
 
 from ._plugin_manager import PluginManager
 from .manifest.contributions import (

--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union, cast, overload
-
-from typing_extensions import Literal
+from typing import (
+    TYPE_CHECKING,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 from . import PluginManager
 from .manifest.utils import v1_to_v2

--- a/npe2/manifest/_package_metadata.py
+++ b/npe2/manifest/_package_metadata.py
@@ -1,9 +1,8 @@
 from importlib.metadata import metadata
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Extra, Field, constr, root_validator
 from pydantic.fields import SHAPE_LIST
-from typing_extensions import Literal
 
 if TYPE_CHECKING:
     import email.message

--- a/npe2/manifest/contributions/_configuration.py
+++ b/npe2/manifest/contributions/_configuration.py
@@ -25,10 +25,9 @@ SOFTWARE.
 
 """
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Type, Union
 
 from pydantic import BaseModel, Extra, Field, root_validator, validator
-from typing_extensions import Literal
 
 JsonType = Union[
     Literal["string"],

--- a/npe2/manifest/contributions/_themes.py
+++ b/npe2/manifest/contributions/_themes.py
@@ -1,8 +1,7 @@
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, color
 from pydantic.fields import Field
-from typing_extensions import Literal
 
 
 # pydantic doesn't implement color equality?

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -21,11 +21,9 @@ from typing import (
 from ..types import PythonName
 
 if TYPE_CHECKING:
+    from typing import Protocol
+
     from npe2.manifest.schema import PluginManifest
-
-
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
 
     from .._command_registry import CommandRegistry
     from .contributions import ContributionPoints

--- a/npe2/types.py
+++ b/npe2/types.py
@@ -3,14 +3,14 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     NewType,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     Union,
 )
-
-from typing_extensions import Literal, Protocol
 
 if TYPE_CHECKING:
     import magicgui.widgets


### PR DESCRIPTION
We had some `from typing_extensions` imports, but didn't have it listed in our dependencies.  It's something that ends up being in almost every environment, so we didn't have any issues yet (I guess), but it should have been listed in deps.  Turns out though, that everything we were importing there is now available in python >=3.8, so this PR just changes those imports to `from typing`