### PR TITLE
Add PluginManager `dict()` method to export state of manager

### DIFF
--- a/npe2/plugin_manager.py
+++ b/npe2/plugin_manager.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from os import PathLike
-    from typing import Iterator, List, NewType, Optional, Sequence, Tuple, Union
+    from typing import Any, Iterator, List, NewType, Optional, Sequence, Tuple, Union
 
     from npe2 import PluginManifest
-    from npe2._plugin_manager import PluginContext
+    from npe2._plugin_manager import InclusionSet, PluginContext
     from npe2.manifest import contributions
 
     from ._plugin_manager import PluginManager
@@ -25,6 +25,12 @@ def instance() -> PluginManager:
 
 def discover(paths: Sequence[str] = (), clear=False, include_npe1=False) -> None:
     """Discover and index plugin manifests in the environment."""
+
+
+def dict(
+    self, *, include: InclusionSet = None, exclude: InclusionSet = None
+) -> Dict[str, Any]:
+    """Return a dictionary with the state of the plugin manager."""
 
 
 def index_npe1_adapters() -> None:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -198,3 +198,21 @@ def test_warn_on_register_disabled(uses_sample_plugin, plugin_manager: PluginMan
     plugin_manager._manifests.pop(SAMPLE_PLUGIN_NAME)  # NOT good way to "unregister"
     with pytest.warns(UserWarning):
         plugin_manager.register(mf)
+
+
+def test_plugin_manager_dict(uses_sample_plugin, plugin_manager: PluginManager):
+    """Test exporting the plugin manager state with `dict()`."""
+    d = plugin_manager.dict()
+    assert SAMPLE_PLUGIN_NAME in d["plugins"]
+    assert "disabled" in d
+    assert "activated" in d
+
+    d = plugin_manager.dict(
+        include={"contributions", "package_metadata.version"},
+        exclude={"contributions.writers", "contributions.readers"},
+    )
+    plugin_dict = d["plugins"][SAMPLE_PLUGIN_NAME]
+    assert set(plugin_dict) == {"contributions", "package_metadata"}
+    contribs = set(plugin_dict["contributions"])
+    assert "readers" not in contribs
+    assert "writers" not in contribs


### PR DESCRIPTION
This adds a `dict()` method, akin to the `BaseModel.dict()` method on the manifests, that allows the state of the plugin manager to be exported, allowing for `include` and `exclude` arguments to be passed to each [manifest `dict()` method.](https://pydantic-docs.helpmanual.io/usage/exporting_models/)

This will come in handy for the `npe2 list` command line argument (#192 ) (but also provides a direct programmatic way)

```python
In [8]: pm.dict(include={'contributions'}, exclude={'contributions.commands', 'contributions.themes'})
Out[8]:
{
    'plugins': {
        'napari-svg': {
            'contributions': {
                'readers': None,
                'writers': [
                    {'command': 'napari-svg.svg_writer', 'layer_types': ['image*', 'labels*', 'points*', 'shapes*', 'vectors*'], 'filename_extensions': ['.svg'], 'display_name': ''}
                ],
                'widgets': None,
                'sample_data': None,
                'menus': {},
                'submenus': None
            }
        }
    },
    'disabled': set(),
    'activated': set()
}
```