### PR TITLE
index npe1 stuff on `npe2 list`

### DIFF
--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -253,6 +253,7 @@ def list(
 
     pm = PluginManager.instance()
     pm.discover(include_npe1=True)
+    pm.index_npe1_adapters()
     pm_dict = pm.dict(include={f.lstrip("!") for f in normed_fields})
     rows = sorted(_make_rows(pm_dict, normed_fields), key=lambda r: r[sort_index])
 


### PR DESCRIPTION
Just noticed that the plugin manager `.dict()` method is not inducing npe1 shim indexing like the previous direct access of `manifest.contributions` was doing.  I think that's something to look into in another PR, but this fixes it for now by explicitly forcing indexing