### PR TITLE
Always mock cache in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,7 @@ def mock_npe1_pm_with_plugin(npe1_repo, npe1_plugin_module):
                     (npe1_repo / "setup.py").unlink()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_cache(tmp_path, monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(_npe1_adapter, "ADAPTER_CACHE", tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,7 +136,7 @@ def test_cli_main(monkeypatch, sample_path):
     assert e.value.code == 0
 
 
-def test_cli_cache_list_empty(mock_cache):
+def test_cli_cache_list_empty():
     result = runner.invoke(app, ["cache", "--list"])
     assert "Nothing cached" in result.stdout
     assert result.exit_code == 0
@@ -156,7 +156,7 @@ def test_cli_cache_list_named(uses_npe1_plugin, mock_cache):
     assert result.exit_code == 0
 
 
-def test_cli_cache_clear_empty(mock_cache):
+def test_cli_cache_clear_empty():
     result = runner.invoke(app, ["cache", "--clear"])
     assert "Nothing to clear" in result.stdout
     assert result.exit_code == 0


### PR DESCRIPTION
tests in #198 had a side-effect of writing cached manifests (I forgot to add the mock_cache fixture).  This PR just auto-uses the mock_cache fixture, since there's never any reason to actually write a (persistent) cache during tests.