### PR TITLE
Fix `npe2 list` when a dotted field key is empty

### DIFF
--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -178,7 +178,7 @@ def _make_rows(pm_dict: dict, normed_fields: Sequence[str]) -> Iterator[List]:
             if not val and "." in field:
                 parts = field.split(".")
                 val = info
-                while parts and val:
+                while parts and hasattr(val, "__getitem__"):
                     val = val[parts.pop(0)]
 
             # negate fields starting with !

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -178,7 +178,7 @@ def _make_rows(pm_dict: dict, normed_fields: Sequence[str]) -> Iterator[List]:
             if not val and "." in field:
                 parts = field.split(".")
                 val = info
-                while parts:
+                while parts and val:
                     val = val[parts.pop(0)]
 
             # negate fields starting with !


### PR DESCRIPTION
Fixes a bug when a dotted field name has been requested in `npe2 list` (such as `package_metadata.version`) if one of the upper level names doesn't exist (i.e. if `package_metadata` is `None`)
