### PR TITLE
Fix documentation links

### DIFF
--- a/_docs/templates/_npe2_contributions.md.jinja
+++ b/_docs/templates/_npe2_contributions.md.jinja
@@ -7,7 +7,7 @@ Here is a list of all available **Contributions**:
 {# list all contributions first #}
 {%- for name, contrib in contributions.items() %}
 {%- if not contrib.hide_docs %}
-- [`{{ name }}`](#contributions-{{ name|replace('_', '-') }})
+- [`{{ name }}`](contributions-{{ name|replace('_', '-') }})
 {%- endif -%}
 {% endfor %}
 
@@ -18,7 +18,7 @@ is being discussed.
 {# now, iterate through all contributions and show fields and #}
 {%- for contrib_name, contrib in contributions.items() -%}
 {% if not contrib.hide_docs -%}
-(contributions-{{contrib_name}})=
+(contributions-{{ contrib_name|replace('_', '-') }})=
 ## `contributions.{{contrib_name}}`
 {# check if this is a single type, or a union #}
 {%- if contrib['items']['anyOf'] is defined %}
@@ -40,7 +40,7 @@ This contribution accepts {{ type_names|length }} schema types
 {{ type.description }}
 
 {% if contrib_name|has_guide %}
-See the [{{ contrib_name.title()|replace('_', ' ') }} Guide](./guides.html#{{ contrib_name|replace('_', '-') }}-contribution-guide)
+See the [{{ contrib_name.title()|replace('_', ' ') }} Guide]({{ contrib_name|replace('_', '-') }}-contribution-guide)
 for more details on implementing this contribution.
 {% endif %}
 

--- a/_docs/templates/_npe2_readers_guide.md.jinja
+++ b/_docs/templates/_npe2_readers_guide.md.jinja
@@ -36,7 +36,7 @@ otherwise, they will not be invoked when a directory is passed to `viewer.open`.
 
 **manifest**
 
-See [Readers contribution reference](./contributions.html#contributions-readers)
+See [Readers contribution reference](contributions-readers)
 for field details.
 
 ```yaml

--- a/_docs/templates/_npe2_sample_data_guide.md.jinja
+++ b/_docs/templates/_npe2_sample_data_guide.md.jinja
@@ -22,7 +22,7 @@ or **Sample Data Function** that generates layer data on demand.
 
 **manifest**
 
-See [Sample Data contribution reference](./contributions.html#contributions-sample-data)
+See [Sample Data contribution reference](contributions-sample-data)
 for field details.
 
 ```yaml

--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -53,7 +53,7 @@ specification:
    autogenerate a widget using `magicgui.magicgui`.  In the first generation
    `napari_plugin_engine`, this was the `napari_experimental_provide_function`
    hook specification.  In the new `npe2` pattern, one uses the `autogenerate`
-   field in the [WidgetContribution](./contributions.html#contributions-widgets).
+   field in the [WidgetContribution](contributions-widgets).
 
 
 ### Widget example
@@ -68,8 +68,7 @@ specification:
 
 **manifest**
 
-See [Widgets contribution reference](./contributions.html#contributions-widgets)
-for field details.
+See [Widgets contribution reference](contributions-widgets) for field details.
 
 ```yaml
 {{ 'widgets'|example_contribution }}

--- a/_docs/templates/_npe2_writers_guide.md.jinja
+++ b/_docs/templates/_npe2_writers_guide.md.jinja
@@ -22,7 +22,7 @@ Writer plugins are *functions* that:
 3. Return a list of strings containing the path(s) that were successfully written.
 
 They must follow one of two calling conventions (where the convention used
-is determined by the [`layer_type` constraints](#layer-type-constraints) provided
+is determined by the [`layer_type` constraints](layer-type-constraints) provided
 by the corresponding writer contribution in the manifest).
 
 #### 1. single-layer writer
@@ -63,11 +63,12 @@ by the corresponding writer contribution in the manifest).
    MultiWriterFunction = Callable[[str, List[FullLayerData]], List[str]]
    ```
 
+(layer-type-constraints)=
 ### Layer type constraints
 
 Individual writer contributions are determined to be **single-layer writers** or
 **multi-layer writers** based on their **`writer.layer_types`** constraints
-provided in the [contribution metadata](./contributions.html#contributions-writers).
+provided in the [contribution metadata](contributions-writers).
 
 A writer plugin declares that it can accept between *m* and *n* layers of a
 specific *type* (where *0 ≤ m ≤ n*), using regex-like syntax with the special
@@ -113,7 +114,7 @@ and a `vectors` layer, because `vectors` is not listed in the `layer_types`.
 
 **manifest**
 
-See [Writers contribution reference](./contributions.html#contributions-writers)
+See [Writers contribution reference](contributions-writers)
 for field details.
 
 ```yaml


### PR DESCRIPTION
This PR fixes several broken links in the documentation, mostly those referring to local anchors that are not well parsed by myst and need their own definitions.

This also fixes one instance where the anchor name (`contributions-sample_data`) was not correctly written from the template.