### PR TITLE
add cron task to fetch manifests

### DIFF
--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -31,4 +31,5 @@ jobs:
         with:
           branch: manifests
           file_pattern: manifests/*.json
+          skip_checkout: true
           push_options: --force

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -1,12 +1,11 @@
 name: Fetch manifests
 
 on:
-  push:
   pull_request:
-  workflow_dispatch:
-  schedule:
-    # “At 6am and 6pm”
-    - cron: "0 6,18 * * *"
+  # workflow_dispatch:
+  # schedule:
+  #   # “At 6am and 6pm”
+  #   - cron: "0 6,18 * * *"
 
 jobs:
   fetch:

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -1,12 +1,12 @@
 name: Fetch manifests
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
+  schedule:
+    # “At 6am and 6pm”
+    - cron: "0 6,18 * * *"
 
 jobs:
-
   fetch:
     name: Fetch
     runs-on: ubuntu-latest
@@ -23,10 +23,7 @@ jobs:
           pip install -e .
           npe2 fetch --all
 
-      - name: push results
-        uses: s0/git-publish-subdir-action@develop
-        env:
-          REPO: self
-          BRANCH: manifests
-          FOLDER: manifests
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: manifests
+          file_pattern: manifests/*.json

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           branch: manifests
           file_pattern: manifests/*.json
+          skip_checkout: true

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           branch: manifests
           file_pattern: manifests/*.json
-          skip_checkout: true
+          push_options: --force

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -1,6 +1,8 @@
 name: Fetch manifests
 
 on:
+  push:
+  pull_request:
   workflow_dispatch:
   schedule:
     # “At 6am and 6pm”

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -1,0 +1,32 @@
+name: Fetch manifests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  fetch:
+    name: Fetch
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: fetch
+        run: |
+          pip install -U pip
+          pip install -e .
+          npe2 fetch --all
+
+      - name: push results
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: manifests
+          FOLDER: manifests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -1,11 +1,10 @@
 name: Fetch manifests
 
 on:
-  pull_request:
-  # workflow_dispatch:
-  # schedule:
-  #   # “At 6am and 6pm”
-  #   - cron: "0 6,18 * * *"
+  workflow_dispatch:
+  schedule:
+    # “At 6am and 6pm”
+    - cron: "0 6,18 * * *"
 
 jobs:
   fetch:

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.PAT }}
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.head_ref }}
           token: ${{ secrets.PAT }}
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/fetch_manifests.yml
+++ b/.github/workflows/fetch_manifests.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
 
       - uses: actions/setup-python@v4
         with:

--- a/npe2/_fetch.py
+++ b/npe2/_fetch.py
@@ -272,7 +272,7 @@ def _try_fetch_and_write_manifest(args: Tuple[str, str, Path]):
     FORMAT = "json"
     INDENT = None
 
-    try:
+    try:  # pragma: no cover
         mf = fetch_manifest(name, version=version)
         manifest_string = getattr(mf, FORMAT)(exclude=set(), indent=INDENT)
 
@@ -283,7 +283,7 @@ def _try_fetch_and_write_manifest(args: Tuple[str, str, Path]):
         return name, {"version": version, "error": str(e)}
 
 
-def fetch_all_manifests(dest="manifests"):
+def _fetch_all_manifests(dest="manifests"):
     from concurrent.futures import ThreadPoolExecutor
 
     dest = Path(dest)
@@ -291,6 +291,6 @@ def fetch_all_manifests(dest="manifests"):
 
     args = [(name, ver, dest) for name, ver in sorted(get_hub_plugins().items())]
     with ThreadPoolExecutor() as executor:
-        errors = list(executor.map(_try_fetch_and_write_manifest, args[8:15]))
+        errors = list(executor.map(_try_fetch_and_write_manifest, args))
     _errors = {tup[0]: tup[1] for tup in errors if tup}
     (dest / "errors.json").write_text(json.dumps(_errors, indent=2))

--- a/npe2/_fetch.py
+++ b/npe2/_fetch.py
@@ -291,6 +291,6 @@ def fetch_all_manifests(dest="manifests"):
 
     args = [(name, ver, dest) for name, ver in sorted(get_hub_plugins().items())]
     with ThreadPoolExecutor() as executor:
-        errors = list(executor.map(_try_fetch_and_write_manifest, args[10:15]))
+        errors = list(executor.map(_try_fetch_and_write_manifest, args[8:15]))
     _errors = {tup[0]: tup[1] for tup in errors if tup}
     (dest / "errors.json").write_text(json.dumps(_errors, indent=2))

--- a/npe2/_fetch.py
+++ b/npe2/_fetch.py
@@ -11,7 +11,7 @@ from importlib import metadata
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 from urllib.request import urlopen
 from zipfile import ZipFile
 
@@ -265,3 +265,29 @@ def get_hub_plugin(plugin_name: str) -> Dict[str, Any]:
     """Return hub information for a specific plugin."""
     with urlopen(f"https://api.napari-hub.org/plugins/{plugin_name}") as r:
         return json.load(r)
+
+
+def _try_fetch_and_write_manifest(args: Tuple[str, str, Path]):
+    name, version, dest = args
+
+    try:
+        mf = fetch_manifest(name, version=version)
+        manifest_string = mf.yaml(exclude=set(), indent=2)
+        (dest / f"{name}.yaml").write_text(manifest_string)
+        print(f"✅ {name}")
+    except Exception as e:
+        print(f"❌ {name}")
+        return name, {"version": version, "error": str(e)}
+
+
+def fetch_all_manifests(dest="manifests"):
+    from concurrent.futures import ThreadPoolExecutor
+
+    dest = Path(dest)
+    dest.mkdir(exist_ok=True)
+
+    args = [(name, ver, dest) for name, ver in get_hub_plugins().items()]
+    with ThreadPoolExecutor() as executor:
+        errors = list(executor.map(_try_fetch_and_write_manifest, args[:20]))
+
+    (dest / "errors.json").write_text(json.dumps(dict(errors), indent=2))

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -310,9 +310,11 @@ def list(
 
 
 def _fetch_all_manifests():
+    """Fetch all manifests and dump to "manifests" folder."""
     from npe2._fetch import fetch_all_manifests
 
     fetch_all_manifests()
+    raise typer.Exit(0)
 
 
 @app.command()
@@ -344,7 +346,7 @@ def fetch(
         ".json, or .toml). Otherwise, will print to stdout.",
     ),
     all: Optional[bool] = typer.Option(
-        False,
+        None,
         "--all",
         help="Fetch manifests for ALL known plugins (will be SLOW)",
         callback=_fetch_all_manifests,

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -312,9 +312,9 @@ def list(
 def _fetch_all_manifests(doit: bool):
     """Fetch all manifests and dump to "manifests" folder."""
     if doit:
-        from npe2._fetch import fetch_all_manifests
+        from npe2 import _fetch
 
-        fetch_all_manifests()
+        _fetch._fetch_all_manifests()
         raise typer.Exit(0)
 
 

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -309,6 +309,12 @@ def list(
             typer.echo(template.format(**r, ncontrib=ncontrib))
 
 
+def _fetch_all_manifests():
+    from npe2._fetch import fetch_all_manifests
+
+    fetch_all_manifests()
+
+
 @app.command()
 def fetch(
     name: str,
@@ -336,6 +342,13 @@ def fetch(
         exists=False,
         help="If provided, will write manifest to filepath (must end with .yaml, "
         ".json, or .toml). Otherwise, will print to stdout.",
+    ),
+    all: Optional[bool] = typer.Option(
+        False,
+        "--all",
+        help="Fetch manifests for ALL known plugins (will be SLOW)",
+        callback=_fetch_all_manifests,
+        is_eager=True,
     ),
 ):
     """Fetch manifest from remote package.

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -309,12 +309,13 @@ def list(
             typer.echo(template.format(**r, ncontrib=ncontrib))
 
 
-def _fetch_all_manifests():
+def _fetch_all_manifests(doit: bool):
     """Fetch all manifests and dump to "manifests" folder."""
-    from npe2._fetch import fetch_all_manifests
+    if doit:
+        from npe2._fetch import fetch_all_manifests
 
-    fetch_all_manifests()
-    raise typer.Exit(0)
+        fetch_all_manifests()
+        raise typer.Exit(0)
 
 
 @app.command()


### PR DESCRIPTION
This will run a cron job twice a day to gather manifests and put them in the [manifests branch](https://github.com/napari/npe2/tree/manifests)

I actually don't expect this to work until it's on the main branch, so will likely merge to test.  I tested on my personal branch and it works.  It doesn't really affect any of the repo (except the addition of an `--all` flag to `npe2 fetch`)