### PR TITLE
[wip] use copier for npe2 create

### DIFF
--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -522,5 +522,34 @@ def compile(
     _pprint_formatted(manifest_string, format)
 
 
+@app.command()
+def create(plugin_name: str):
+    """Create a new napari plugin"""
+    import subprocess
+    from shutil import which
+
+    if not which("copier"):
+        text = typer.style(
+            "This command requires the `copier` package.\n"
+            "Install it now into your current environment? [y/N]",
+            fg="yellow",
+        )
+        if not typer.prompt(text, type=bool, default=False, show_default=False):
+            raise typer.Exit("Aborted")
+
+        copier = "git+https://github.com/tlambert03/copier.git@validation"
+        subprocess.check_call([sys.executable, "-m", "pip", "install", copier])
+
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "copier",
+            "gh:tlambert03/napari-plugin-template",
+            plugin_name,
+        ]
+    )
+
+
 def main():
     app()

--- a/npe2/cli.py
+++ b/npe2/cli.py
@@ -531,7 +531,7 @@ def create(plugin_name: str):
     if not which("copier"):
         text = typer.style(
             "This command requires the `copier` package.\n"
-            "Install it now into your current environment? [y/N]",
+            "Install it now into your current environment with pip? [y/N]",
             fg="yellow",
         )
         if not typer.prompt(text, type=bool, default=False, show_default=False):


### PR DESCRIPTION
Been playing with using [copier](https://copier.readthedocs.io/en/stable/) as a replacement for cookiecutter.  Generally much happier with it, mostly because of support for 1) conditionals in the questions, 2) much better updating when the upstream template changes 3) validation (after [my PR merges](https://github.com/copier-org/copier/pull/719))

I built a copier template here: https://github.com/tlambert03/napari-plugin-template

this PR would address #54 and add an `npe2 create` command that would bootstrap a new plugin, as @nclack proposed.  Most of the work will be in tailoring that plugin template repo as we want it.  and I also think we should create an actual webpage documentation for it.

if we eventually wanted to go even farther than copier, we could just keep the command