### PR TITLE
fix getting contribution.plugin_name with dotted names

### DIFF
--- a/npe2/_plugin_manager.py
+++ b/npe2/_plugin_manager.py
@@ -456,6 +456,9 @@ class PluginManager:
     def get_manifest(self, plugin_name: str) -> PluginManifest:
         """Get manifest for `plugin_name`"""
         if plugin_name not in self._manifests:
+            with contextlib.suppress(KeyError):
+                plugin_name = self._plugin_for(plugin_name)
+        if plugin_name not in self._manifests:
             msg = f"Manifest key {plugin_name!r} not found in {list(self._manifests)}"
             raise KeyError(msg)
         return self._manifests[plugin_name]

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from functools import total_ordering
+from functools import cached_property, total_ordering
 from importlib import import_module
 from typing import (
     TYPE_CHECKING,
@@ -74,10 +74,12 @@ class Executable(Generic[R]):
             _registry = PluginManager.instance().commands
         return _registry.get(self.command)
 
-    @property
-    def plugin_name(self: ProvidesCommand):
-        # takes advantage of the fact that command always starts with manifest.name
-        return self.command.split(".")[0]
+    @cached_property
+    def plugin_name(self: ProvidesCommand) -> str:
+        from .._plugin_manager import PluginManager
+
+        # CAUTION: this only works for the global plugin manager instance
+        return PluginManager.instance()._plugin_for(self.command)
 
 
 @total_ordering

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -224,3 +224,30 @@ def test_plugin_context_dispose():
     pm.get_context("test").register_disposable(mock)
     pm.deactivate("test")
     mock.assert_called_once()
+
+
+def test_dotted_plugin_name(npe2pm):
+    """Test that"""
+    name = "some.namespaced.plugin"
+    cmd_id = f"{name}.frame_rate_widget"
+    mf = PluginManifest(
+        name=name,
+        contributions={
+            "commands": [
+                {
+                    "id": cmd_id,
+                    "title": "open my widget",
+                }
+            ],
+            "widgets": [
+                {
+                    "command": cmd_id,
+                    "display_name": "Plot frame rate",
+                }
+            ],
+        },
+    )
+    npe2pm.commands.register(cmd_id, lambda: None)
+    npe2pm.register(mf)
+    assert npe2pm._plugin_for(cmd_id) == name
+    assert mf.contributions.widgets[0].plugin_name == name  # type: ignore


### PR DESCRIPTION
should fix #232 

This tracks down two more places where we made the assumption that a command id would start with a name _without periods_.  The big one causing #232 was the `plugin_name` property on the `Executable` mixin.

I looked through the rest of the code for `split(".")` and I think/hope this covers them all.  test added