### PR TITLE
feat: add icon to manifest

### DIFF
--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -66,3 +66,16 @@ def display_name(v: str) -> str:
             "non-word character."
         )
     return v
+
+
+def icon_path(v: str) -> str:
+    if not v:
+        return ""
+    if v.startswith("http"):
+        if not v.startswith("https://"):
+            raise ValueError(
+                f"{v} is not a valid icon URL. It must start with 'https://'"
+            )
+        return v
+    assert isinstance(v, str), f"{v} must be a string"  # pragma: no cover
+    return v

--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -77,5 +77,5 @@ def icon_path(v: str) -> str:
                 f"{v} is not a valid icon URL. It must start with 'https://'"
             )
         return v
-    assert isinstance(v, str), f"{v} must be a string"  # pragma: no cover
+    assert isinstance(v, str), f"{v} must be a string"
     return v

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -74,6 +74,17 @@ class PluginManifest(ImportExportModel):
         "results, change this to `'hidden'`.",
     )
 
+    icon: str = Field(
+        "",
+        description="The path to a square PNG icon of at least 128x128 pixels (256x256 "
+        "for Retina screens). May be one of:\n"
+        "  - a secure (https) URL\n"
+        "  - a path to arelative to to the manifest file\n"
+        "  - a string in the format `{package}:{resource}`, where `package` and "
+        "`resource` are arguments to `importlib.resources.path(package, resource)`, "
+        "(e.g. `top_module.some_folder:my_logo.png`).",
+    )
+
     # Plugins rely on certain guarantees to interoperate propertly with the
     # plugin engine. These include the manifest specification, conventions
     # around python packaging, command api's, etc. Together these form a

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -79,11 +79,12 @@ class PluginManifest(ImportExportModel):
         description="The path to a square PNG icon of at least 128x128 pixels (256x256 "
         "for Retina screens). May be one of:\n"
         "  - a secure (https) URL\n"
-        "  - a path to arelative to to the manifest file\n"
+        "  - a path relative to the manifest file, (must be shipped in the sdist)\n"
         "  - a string in the format `{package}:{resource}`, where `package` and "
         "`resource` are arguments to `importlib.resources.path(package, resource)`, "
         "(e.g. `top_module.some_folder:my_logo.png`).",
     )
+    _validate_icon_path = validator("icon", allow_reuse=True)(_validators.icon_path)
 
     # Plugins rely on certain guarantees to interoperate propertly with the
     # plugin engine. These include the manifest specification, conventions

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -2,6 +2,7 @@ name: my-plugin
 display_name: My Plugin
 on_activate: my_plugin:activate
 on_deactivate: my_plugin:deactivate
+icon: https://picsum.photos/256
 contributions:
   commands:
     - id: my-plugin.hello_world

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -178,3 +178,7 @@ def test_visibility():
 
     with pytest.raises(ValidationError):
         mf = PluginManifest(name="myplugin", visibility="other")
+
+
+def test_icon():
+    PluginManifest(name="myplugin", icon="my_plugin:myicon.png")

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -80,6 +80,11 @@ def _mutator_schema_version_too_high(data):
     data["schema_version"] = "999.999.999"
 
 
+def _mutator_invalid_icon(data):
+    """is not a valid icon URL. It must start with 'https://'"""
+    data["icon"] = "http://example.com/icon.png"
+
+
 @pytest.mark.parametrize(
     "mutator",
     [
@@ -95,6 +100,7 @@ def _mutator_schema_version_too_high(data):
         _mutator_writer_invalid_file_extension_1,
         _mutator_writer_invalid_file_extension_2,
         _mutator_schema_version_too_high,
+        _mutator_invalid_icon,
     ],
 )
 def test_invalid(mutator, uses_sample_plugin):


### PR DESCRIPTION
adds an icon field to the manifest, which will allow us to associate an icon with each plugin in the plugin installer