### PR TITLE
bug: ignore extra fields on manifest

### DIFF
--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -35,7 +35,7 @@ class DiscoverResults(NamedTuple):
 class PluginManifest(ImportExportModel):
     class Config:
         underscore_attrs_are_private = True
-        extra = Extra.forbid
+        extra = Extra.ignore
         validate_assignment = True
 
     # VS Code uses <publisher>.<name> as a unique ID for the extension

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -196,17 +196,20 @@ class PluginManifest(ImportExportModel):
 
     @root_validator
     def _validate_root(cls, values: dict) -> dict:
+        mf_name = values.get("name")
+
         # validate schema version
         declared_version = Version.parse(values.get("schema_version", ""))
         current_version = Version.parse(SCHEMA_VERSION)
         if current_version < declared_version:
-            raise ValueError(
-                f"The declared schema version '{declared_version}' is "
-                f"newer than npe2's schema version: '{current_version}'. You may "
-                "need to upgrade npe2."
+            import warnings
+
+            warnings.warn(
+                f"The declared schema version for plugin {mf_name!r} "
+                f"({declared_version}) is newer than npe2's schema version "
+                f"({current_version}). Things may break, you should upgrade npe2."
             )
 
-        mf_name = values.get("name")
         invalid_commands: List[str] = []
         if values.get("contributions") is not None:
             invalid_commands.extend(

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -21,7 +21,7 @@ from .utils import Executable, Version
 logger = getLogger(__name__)
 
 
-SCHEMA_VERSION = "0.1.0"
+SCHEMA_VERSION = "0.2.0"
 ENTRY_POINT = "napari.manifest"
 NPE1_ENTRY_POINT = "napari.plugin"
 

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -48,13 +48,6 @@ def _mutator_python_name_starts_with_number(data):
     data["contributions"]["commands"][0]["python_name"] = "1starts_with_number"
 
 
-def _mutator_no_contributes_extra_field(data):
-    """extra fields not permitted"""
-    # Contributions used to be called contributes.
-    data["invalid_extra_name"] = data["contributions"]
-    del data["contributions"]
-
-
 def _mutator_writer_requires_non_empty_layer_types(data):
     """layer_types must not be empty"""
     data["contributions"]["writers"][0]["layer_types"] = []
@@ -89,7 +82,6 @@ def _mutator_schema_version_too_high(data):
         _mutator_python_name_no_colon,
         _mutator_python_name_locals,
         _mutator_python_name_starts_with_number,
-        _mutator_no_contributes_extra_field,
         _mutator_writer_requires_non_empty_layer_types,
         _mutator_writer_invalid_layer_type_constraint,
         _mutator_writer_invalid_file_extension_1,

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -68,11 +68,6 @@ def _mutator_writer_invalid_file_extension_2(data):
     data["contributions"]["writers"][0]["filename_extensions"] = ["."]
 
 
-def _mutator_schema_version_too_high(data):
-    """The declared schema version '999.999.999' is newer than npe2's schema version"""
-    data["schema_version"] = "999.999.999"
-
-
 def _mutator_invalid_icon(data):
     """is not a valid icon URL. It must start with 'https://'"""
     data["icon"] = "http://example.com/icon.png"
@@ -91,7 +86,6 @@ def _mutator_invalid_icon(data):
         _mutator_writer_invalid_layer_type_constraint,
         _mutator_writer_invalid_file_extension_1,
         _mutator_writer_invalid_file_extension_2,
-        _mutator_schema_version_too_high,
         _mutator_invalid_icon,
     ],
 )
@@ -109,6 +103,13 @@ def test_invalid(mutator, uses_sample_plugin):
     with pytest.raises(ValidationError) as excinfo:
         PluginManifest(**data)
     assert mutator.__doc__ in str(excinfo.value)
+
+
+def test_schema_version_too_high():
+    with pytest.warns(
+        UserWarning, match=r"\(999.999.999\) is newer than npe2's schema version"
+    ):
+        PluginManifest(name="sample", schema_version="999.999.999")
 
 
 def test_invalid_python_name(uses_sample_plugin):


### PR DESCRIPTION
closes #236 and reverts a change from #14

While forbidding extra keys on makes for nicer validation if a plugin developer enters a field name incorrectly, it makes it so that we can't add fields to the manifest without making them backwards incompatible.  Normally, adding a field should be an easy migration in a schema, but currently it's hard. 

I'm not quite sure what we should do now to allow plugin developers to adopt new manifest keys like (`icon` or `visibility`) without making their plugins incompatible with any versions of npe2 earlier than our next release.  but this PR will help prevent that going forward.