### PR TITLE
fix: alternate fix for dotted plugin_name

### DIFF
--- a/npe2/manifest/contributions/_readers.py
+++ b/npe2/manifest/contributions/_readers.py
@@ -1,13 +1,13 @@
 from functools import wraps
 from typing import List, Optional
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import Extra, Field
 
 from ...types import ReaderFunction
 from ..utils import Executable, v2_to_v1
 
 
-class ReaderContribution(BaseModel, Executable[Optional[ReaderFunction]]):
+class ReaderContribution(Executable[Optional[ReaderFunction]]):
     """Contribute a file reader.
 
     Readers may be associated with specific **filename_patterns** (e.g. "*.tif",

--- a/npe2/manifest/contributions/_sample_data.py
+++ b/npe2/manifest/contributions/_sample_data.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import BaseModel
 from pydantic.fields import Field
+from pydantic.generics import GenericModel
 
 from ...types import LayerData
 from ..utils import Executable
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ..._command_registry import CommandRegistry
 
 
-class _SampleDataContribution(BaseModel, ABC):
+class _SampleDataContribution(GenericModel, ABC):
     """Contribute sample data for use in napari.
 
     Sample data can take the form of a **command** that returns layer data, or a simple

--- a/npe2/manifest/contributions/_widgets.py
+++ b/npe2/manifest/contributions/_widgets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Optional
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import Extra, Field
 
 from ...types import Widget
 from ..utils import Executable
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ..._command_registry import CommandRegistry
 
 
-class WidgetContribution(BaseModel, Executable[Widget]):
+class WidgetContribution(Executable[Widget]):
     """Contribute a widget that can be added to the napari viewer.
 
     Widget contributions point to a **command** that, when called, returns a widget

--- a/npe2/manifest/contributions/_writers.py
+++ b/npe2/manifest/contributions/_writers.py
@@ -113,7 +113,7 @@ class LayerTypeConstraint(BaseModel):
         return cls(layer_type=lt, bounds=bounds)
 
 
-class WriterContribution(BaseModel, Executable[List[str]]):
+class WriterContribution(Executable[List[str]]):
     r"""Contribute a layer writer.
 
     Writers accept data from one or more layers and write them to file. Writers declare

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from importlib import metadata, util
 from logging import getLogger
 from pathlib import Path
@@ -16,7 +16,7 @@ from . import _validators
 from ._bases import ImportExportModel
 from ._package_metadata import PackageMetadata
 from .contributions import ContributionPoints
-from .utils import Version
+from .utils import Executable, Version
 
 logger = getLogger(__name__)
 
@@ -155,11 +155,17 @@ class PluginManifest(ImportExportModel):
     def __init__(self, **data):
         super().__init__(**data)
         if self.package_metadata is None and self.name:
-            try:
+            with suppress(metadata.PackageNotFoundError):
                 meta = metadata.distribution(self.name).metadata
                 self.package_metadata = PackageMetadata.from_dist_metadata(meta)
-            except metadata.PackageNotFoundError:
-                pass
+
+        if not self.npe1_shim:
+            # assign plugin name on all contributions that have a private
+            # _plugin_name field.
+            for _, value in self.contributions or ():
+                for item in value if isinstance(value, list) else [value]:
+                    if isinstance(item, Executable):
+                        item._plugin_name = self.name
 
     def __hash__(self):
         return hash((self.name, self.package_version))

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -18,6 +18,9 @@ from typing import (
     Union,
 )
 
+from pydantic import PrivateAttr
+from pydantic.generics import GenericModel
+
 from ..types import PythonName
 
 if TYPE_CHECKING:
@@ -51,11 +54,13 @@ SHIM_NAME_PREFIX = "__npe1shim__."
 
 
 # TODO: add ParamSpec when it's supported better by mypy
-class Executable(Generic[R]):
+class Executable(GenericModel, Generic[R]):
     command: str
+    # plugin_name gets populated in `PluginManifest.__init__`
+    _plugin_name: str = PrivateAttr("")
 
     def exec(
-        self: ProvidesCommand,
+        self,
         args: tuple = (),
         kwargs: dict = None,
         _registry: Optional[CommandRegistry] = None,
@@ -65,7 +70,7 @@ class Executable(Generic[R]):
         return self.get_callable(_registry)(*args, **kwargs)
 
     def get_callable(
-        self: ProvidesCommand,
+        self,
         _registry: Optional[CommandRegistry] = None,
     ) -> Callable[..., R]:
         if _registry is None:
@@ -75,9 +80,25 @@ class Executable(Generic[R]):
         return _registry.get(self.command)
 
     @property
-    def plugin_name(self: ProvidesCommand):
-        # takes advantage of the fact that command always starts with manifest.name
-        return self.command.split(".")[0]
+    def plugin_name(self) -> str:
+        """Return the manifest/plugin name for this contribution."""
+        if not self._plugin_name:
+            # we will likely never get here if the contribution was created
+            # as a member of a PluginManifest.
+            # But if not, we can use a couple heuristics...
+            from importlib.metadata import distributions
+
+            # look for a package name in the command id
+            dists = sorted((d.name for d in distributions()), key=len, reverse=True)
+            for name in dists:
+                if self.command.startswith(name):  # pragma: no cover
+                    self._plugin_name = name
+                    break
+            else:
+                # just split on the first period.
+                # Will break for package names with periods
+                self._plugin_name = self.command.split(".")[0]
+        return self._plugin_name
 
 
 @total_ordering

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -24,18 +24,10 @@ from pydantic.generics import GenericModel
 from ..types import PythonName
 
 if TYPE_CHECKING:
-    from typing import Protocol
-
     from npe2.manifest.schema import PluginManifest
 
     from .._command_registry import CommandRegistry
     from .contributions import ContributionPoints
-
-    class ProvidesCommand(Protocol):
-        command: str
-
-        def get_callable(self, _registry: Optional[CommandRegistry] = None):
-            ...
 
 
 def v1_to_v2(path):

--- a/npe2/manifest/utils.py
+++ b/npe2/manifest/utils.py
@@ -81,7 +81,9 @@ class Executable(GenericModel, Generic[R]):
             from importlib.metadata import distributions
 
             # look for a package name in the command id
-            dists = sorted((d.name for d in distributions()), key=len, reverse=True)
+            dists = sorted(
+                (d.metadata["Name"] for d in distributions()), key=len, reverse=True
+            )
             for name in dists:
                 if self.command.startswith(name):  # pragma: no cover
                     self._plugin_name = name

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -182,3 +182,28 @@ def test_visibility():
 
 def test_icon():
     PluginManifest(name="myplugin", icon="my_plugin:myicon.png")
+
+
+def test_dotted_plugin_name():
+    """Test that"""
+    name = "some.namespaced.plugin"
+    cmd_id = f"{name}.frame_rate_widget"
+    mf = PluginManifest(
+        name=name,
+        contributions={
+            "commands": [
+                {
+                    "id": cmd_id,
+                    "title": "open my widget",
+                }
+            ],
+            "widgets": [
+                {
+                    "command": cmd_id,
+                    "display_name": "Plot frame rate",
+                }
+            ],
+        },
+    )
+    assert mf.contributions.widgets
+    assert mf.contributions.widgets[0].plugin_name == name


### PR DESCRIPTION
alternative to #233 

@nclack, this implements option 1 from https://github.com/napari/npe2/pull/233#discussion_r945058646

it populates `Executable._plugin_name` during the `PluginManifest.__init__`, and falls back to option 4 if nothing has been set (i.e. if it's a one-off contribution), and then lastly, to the old period split if nothing is found to be installed