### PR TITLE
feat: add more fetch sources

### DIFF
--- a/npe2/_inspection/_fetch.py
+++ b/npe2/_inspection/_fetch.py
@@ -1,19 +1,30 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
+import subprocess
 import tempfile
 from concurrent.futures import ProcessPoolExecutor
 from contextlib import contextmanager
 from functools import lru_cache
 from importlib import metadata
-from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ContextManager,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+from unittest.mock import patch
 from urllib import error, parse, request
-from urllib.request import urlopen
 from zipfile import ZipFile
 
 from npe2.manifest import PackageMetadata
@@ -112,12 +123,11 @@ def _guard_cwd() -> Iterator[None]:
         os.chdir(current)
 
 
-def _build_wheel(src, dest):
+def _build_wheel(src: Union[str, Path]) -> Path:
     """Build a wheel from a source directory and extract it into dest."""
-    import subprocess
-    from unittest.mock import patch
-
     from build.__main__ import build_package
+
+    dest = Path(src) / "extracted_wheel"
 
     class _QuietPopen(subprocess.Popen):
         """Silence all the noise from build."""
@@ -127,12 +137,12 @@ def _build_wheel(src, dest):
             kwargs["stderr"] = subprocess.DEVNULL
             super().__init__(*args, **kwargs)
 
-    with patch("subprocess.Popen", _QuietPopen):
+    with patch("subprocess.Popen", _QuietPopen), _guard_cwd():
         dist = Path(src) / "dist"
-        with _guard_cwd():
-            build_package(src, dist, ["wheel"])
-            with ZipFile(next((dist).glob("*.whl"))) as zf:
-                zf.extractall(dest)
+        build_package(src, dist, ["wheel"])
+        with ZipFile(next((dist).glob("*.whl"))) as zf:
+            zf.extractall(dest)
+    return dest
 
 
 def get_manifest_from_wheel(src: str) -> PluginManifest:
@@ -143,13 +153,72 @@ def get_manifest_from_wheel(src: str) -> PluginManifest:
             return _manifest_from_extracted_wheel(Path(td))
 
 
-def fetch_manifest(package: str, version: Optional[str] = None) -> PluginManifest:
-    """Fetch a manifest for a pip specifier (package name, possibly with version).
+def _build_src_and_extract_manifest(src_dir: Union[str, Path]) -> PluginManifest:
+    """Build a wheel from a source directory and extract the manifest."""
+    return _manifest_from_extracted_wheel(_build_wheel(src_dir))
+
+
+def _get_manifest_from_zip_url(url: str) -> PluginManifest:
+    """Extract a manifest from a remote source directory zip file.
+
+    Examples
+    --------
+    $ npe2 fetch https://github.com/org/project/archive/refs/heads/master.zip
+    """
+    with _tmp_zip_download(url) as zip_path:
+        src_dir = next(Path(zip_path).iterdir())  # find first directory
+        return _build_src_and_extract_manifest(src_dir)
+
+
+def _get_manifest_from_wheel_url(url: str) -> PluginManifest:
+    """Extract a manifest from a remote wheel file.
+
+    Examples
+    --------
+    $ npe2 fetch https://files.pythonhosted.org/packages/b0/93/a00a1ee154d5ce3540dd5ae081dc53fcfa7498f34ba68a7345ac027a4f96/pycudadecon-0.3.0-py3-none-any.whl  # noqa
+    """
+    with _tmp_zip_download(url) as wheel_dir:
+        return _manifest_from_extracted_wheel(wheel_dir)
+
+
+def _get_manifest_from_targz_url(url: str) -> PluginManifest:
+    """Extract a manifest from a remote source directory tar.gz file.
+
+    Examples
+    --------
+    $ npe2 fetch https://files.pythonhosted.org/packages/4a/84/de031ba465f183c319cb37633c49dfebd57f1ff42bc9744db3f80f7f4093/pycudadecon-0.3.0.tar.gz  # noqa
+    """
+    with _tmp_targz_download(url) as targz_path:
+        src_dir = next(Path(targz_path).iterdir())  # find first directory
+        return _build_src_and_extract_manifest(src_dir)
+
+
+def _get_manifest_from_git_url(url: str) -> PluginManifest:
+    """Extract a manifest from a remote git repository.
+
+    Examples
+    --------
+    $ npe2 fetch https://github.com/tlambert03/napari-dv
+    $ npe2 fetch https://github.com/tlambert03/napari-dv.git
+    $ npe2 fetch git+https://github.com/tlambert03/napari-dv.git
+    """
+    if url.startswith("git+"):
+        url = url[4:]
+
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.run(["git", "clone", url, td], stdout=subprocess.DEVNULL)
+        return _build_src_and_extract_manifest(td)
+
+
+def fetch_manifest(
+    package_or_url: str, version: Optional[str] = None
+) -> PluginManifest:
+    """Fetch a manifest for a pypi package name or URL to a wheel or source.
 
     Parameters
     ----------
-    package : str
-        package name
+    package_or_url : str
+        package name or URL to a git repository or zip file.
     version : Optional[str]
         package version, by default, latest version.
 
@@ -157,12 +226,43 @@ def fetch_manifest(package: str, version: Optional[str] = None) -> PluginManifes
     -------
     PluginManifest
         Plugin manifest for package `specifier`.
+
+    Examples
+    --------
+    >>> fetch_manifest("napari-dv")
+    >>> fetch_manifest("napari-dv", "0.3.0")
+    >>> fetch_manifest("https://github.com/tlambert03/napari-dv")
+    >>> fetch_manifest("git+https://github.com/tlambert03/napari-dv.git")
+    >>> fetch_manifest("https://github.com/org/project/archive/refs/heads/master.zip")
+    >>> fetch_manifest("https://files.pythonhosted.org/.../package-0.3.0-py3-none-any.whl")  # noqa
+    >>> fetch_manifest("https://files.pythonhosted.org/.../package-0.3.0.tar.gz")
     """
-    try:
-        with _tmp_pypi_wheel_download(package, version) as td:
-            return _manifest_from_extracted_wheel(td)
-    except metadata.PackageNotFoundError:
-        return _manifest_from_pypi_sdist(package, version)
+    # not on PyPI check various URL forms
+    if package_or_url.startswith(("http", "git+http")):
+        if package_or_url.endswith(".zip"):
+            return _get_manifest_from_zip_url(package_or_url)
+        if package_or_url.endswith(".whl"):
+            return _get_manifest_from_wheel_url(package_or_url)
+        if package_or_url.endswith(".tar.gz"):
+            return _get_manifest_from_targz_url(package_or_url)
+        if (
+            package_or_url.startswith("git+")
+            or package_or_url.endswith(".git")
+            or "github.com" in package_or_url
+        ):
+            return _get_manifest_from_git_url(package_or_url)
+    else:
+        try:
+            with _tmp_pypi_wheel_download(package_or_url, version) as td:
+                return _manifest_from_extracted_wheel(td)
+        except metadata.PackageNotFoundError:
+            return _manifest_from_pypi_sdist(package_or_url, version)
+        except error.HTTPError:
+            pass
+    raise ValueError(
+        f"Could not interpret {package_or_url!r} as a PYPI package name or URL to a "
+        "wheel or source distribution/zip file."
+    )
 
 
 def _manifest_from_pypi_sdist(
@@ -170,17 +270,13 @@ def _manifest_from_pypi_sdist(
 ) -> PluginManifest:
     """Extract a manifest from a source distribution on pypi."""
     with _tmp_pypi_sdist_download(package, version) as td:
-
         src = next(p for p in td.iterdir() if p.is_dir())
-        wheel_dir = td / "wheel"
-        _build_wheel(src, wheel_dir)
-
-        return _manifest_from_extracted_wheel(wheel_dir)
+        return _build_src_and_extract_manifest(src)
 
 
 @lru_cache
 def _pypi_info(package: str) -> dict:
-    with urlopen(f"https://pypi.org/pypi/{package}/json") as f:
+    with request.urlopen(f"https://pypi.org/pypi/{package}/json") as f:
         return json.load(f)
 
 
@@ -239,29 +335,39 @@ def get_pypi_url(
 
 
 @contextmanager
-def _tmp_pypi_wheel_download(
-    package: str, version: Optional[str] = None
-) -> Iterator[Path]:
-    url = get_pypi_url(package, version=version, packagetype="bdist_wheel")
-    logger.debug(f"downloading wheel for {package} {version or ''}")
-    with tempfile.TemporaryDirectory() as td, urlopen(url) as f:
-        with ZipFile(BytesIO(f.read())) as zf:
+def _tmp_zip_download(url: str) -> Iterator[Path]:
+    """Extract remote zip file to a temporary directory."""
+    with tempfile.TemporaryDirectory() as td, request.urlopen(url) as f:
+        with ZipFile(io.BytesIO(f.read())) as zf:
             zf.extractall(td)
             yield Path(td)
 
 
 @contextmanager
-def _tmp_pypi_sdist_download(
-    package: str, version: Optional[str] = None
-) -> Iterator[Path]:
+def _tmp_targz_download(url: str) -> Iterator[Path]:
+    """Extract remote tar.gz file to a temporary directory."""
     import tarfile
 
-    url = get_pypi_url(package, version=version, packagetype="sdist")
-    logger.debug(f"downloading sdist for {package} {version or ''}")
-    with tempfile.TemporaryDirectory() as td, urlopen(url) as f:
+    with tempfile.TemporaryDirectory() as td, request.urlopen(url) as f:
         with tarfile.open(fileobj=f, mode="r:gz") as tar:
             tar.extractall(td)
             yield Path(td)
+
+
+def _tmp_pypi_wheel_download(
+    package: str, version: Optional[str] = None
+) -> ContextManager[Path]:
+    url = get_pypi_url(package, version=version, packagetype="bdist_wheel")
+    logger.debug(f"downloading wheel for {package} {version or ''}")
+    return _tmp_zip_download(url)
+
+
+def _tmp_pypi_sdist_download(
+    package: str, version: Optional[str] = None
+) -> ContextManager[Path]:
+    url = get_pypi_url(package, version=version, packagetype="sdist")
+    logger.debug(f"downloading sdist for {package} {version or ''}")
+    return _tmp_targz_download(url)
 
 
 @lru_cache
@@ -302,14 +408,14 @@ def get_pypi_plugins() -> Dict[str, str]:
 @lru_cache
 def get_hub_plugins() -> Dict[str, str]:
     """Return {name: latest_version} for all plugins on the hub."""
-    with urlopen("https://api.napari-hub.org/plugins") as r:
+    with request.urlopen("https://api.napari-hub.org/plugins") as r:
         return json.load(r)
 
 
 @lru_cache
 def get_hub_plugin(plugin_name: str) -> Dict[str, Any]:
     """Return hub information for a specific plugin."""
-    with urlopen(f"https://api.napari-hub.org/plugins/{plugin_name}") as r:
+    with request.urlopen(f"https://api.napari-hub.org/plugins/{plugin_name}") as r:
         return json.load(r)
 
 

--- a/npe2/_inspection/_fetch.py
+++ b/npe2/_inspection/_fetch.py
@@ -258,7 +258,7 @@ def fetch_manifest(
         except metadata.PackageNotFoundError:
             return _manifest_from_pypi_sdist(package_or_url, version)
         except error.HTTPError:
-            pass
+            pass  # pragma: no cover
     raise ValueError(  # pragma: no cover
         f"Could not interpret {package_or_url!r} as a PYPI package name or URL to a "
         "wheel or source distribution/zip file."

--- a/npe2/_inspection/_fetch.py
+++ b/npe2/_inspection/_fetch.py
@@ -259,7 +259,7 @@ def fetch_manifest(
             return _manifest_from_pypi_sdist(package_or_url, version)
         except error.HTTPError:
             pass
-    raise ValueError(
+    raise ValueError(  # pragma: no cover
         f"Could not interpret {package_or_url!r} as a PYPI package name or URL to a "
         "wheel or source distribution/zip file."
     )

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from npe2 import fetch_manifest
+from npe2 import PluginManifest, fetch_manifest
 from npe2._inspection._fetch import (
     _manifest_from_pypi_sdist,
     get_hub_plugin,
@@ -105,3 +105,18 @@ def test_get_hub_plugin():
 def test_get_pypi_plugins():
     info = get_pypi_plugins()
     assert "napari-svg" in info
+
+
+@pytest.mark.skipif(not os.getenv("CI"), reason="slow, only run on CI")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://files.pythonhosted.org/packages/fb/01/e59bc1d6ac96f84ce9d7a46cc5422250e047958ead6c5693ed386cf94003/napari_dv-0.3.0.tar.gz",  # noqa
+        "https://files.pythonhosted.org/packages/5d/ae/17779e12ce60d8329306963e1a8dec608465caee582440011ff0c1310715/example_plugin-0.0.7-py3-none-any.whl",  # noqa
+        "git+https://github.com/DragaDoncila/example-plugin.git",
+        # this one doesn't use setuptools_scm, can check direct zip without clone
+        "https://github.com/jo-mueller/napari-stl-exporter/archive/refs/heads/main.zip",
+    ],
+)
+def test_fetch_urls(url):
+    assert isinstance(fetch_manifest(url), PluginManifest)


### PR DESCRIPTION
adds more acceptable arguments to `npe2 fetch`, including a github or `git+http` URL, a zip url, or a direct url to a wheel or tar.gz source dist

```python
>>> fetch_manifest("napari-dv")
>>> fetch_manifest("napari-dv", "0.3.0")
>>> fetch_manifest("https://github.com/tlambert03/napari-dv")
>>> fetch_manifest("git+https://github.com/tlambert03/napari-dv.git")
>>> fetch_manifest("https://github.com/org/project/archive/refs/heads/master.zip")
>>> fetch_manifest("https://files.pythonhosted.org/.../package-0.3.0-py3-none-any.whl") 
>>> fetch_manifest("https://files.pythonhosted.org/.../package-0.3.0.tar.gz")
```