### PR TITLE
fix: relax display name validation

### DIFF
--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -11,7 +11,7 @@ _identifier_plus_dash = "(?:[a-zA-Z_][a-zA-Z_0-9-]+)"
 _dotted_name = f"(?:(?:{_identifier_plus_dash}\\.)*{_identifier_plus_dash})"
 PACKAGE_NAME_PATTERN = re.compile(f"^{_package_name}$", re.IGNORECASE)
 DOTTED_NAME_PATTERN = re.compile(_dotted_name)
-DISPLAY_NAME_PATTERN = re.compile(r"^[^\W_].{1,89}$")
+DISPLAY_NAME_PATTERN = re.compile(r"^[^\W_].{2,89}$")
 PYTHON_NAME_PATTERN = re.compile(f"^({_dotted_name}):({_dotted_name})$")
 COMMAND_ID_PATTERN = re.compile(
     f"^(({_package_name}\\.)*{_python_identifier})$", re.IGNORECASE

--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -11,7 +11,6 @@ _identifier_plus_dash = "(?:[a-zA-Z_][a-zA-Z_0-9-]+)"
 _dotted_name = f"(?:(?:{_identifier_plus_dash}\\.)*{_identifier_plus_dash})"
 PACKAGE_NAME_PATTERN = re.compile(f"^{_package_name}$", re.IGNORECASE)
 DOTTED_NAME_PATTERN = re.compile(_dotted_name)
-DISPLAY_NAME_PATTERN = re.compile(r"^[^\W_][\w -~]{1,38}[^\W_]$")
 PYTHON_NAME_PATTERN = re.compile(f"^({_dotted_name}):({_dotted_name})$")
 COMMAND_ID_PATTERN = re.compile(
     f"^(({_package_name}\\.)*{_python_identifier})$", re.IGNORECASE
@@ -58,12 +57,10 @@ def python_name(name: str) -> str:
 
 
 def display_name(v: str) -> str:
-    if not DISPLAY_NAME_PATTERN.match(v):
+    if not (3 <= len(v) <= 90):
         raise ValueError(
             f"{v} is not a valid display_name.  The display_name must "
-            "be 3-40 characters long, containing printable word characters, "
-            "and must not begin or end with an underscore, white space, or "
-            "non-word character."
+            "be 3-90 characters long."
         )
     return v
 

--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -11,7 +11,7 @@ _identifier_plus_dash = "(?:[a-zA-Z_][a-zA-Z_0-9-]+)"
 _dotted_name = f"(?:(?:{_identifier_plus_dash}\\.)*{_identifier_plus_dash})"
 PACKAGE_NAME_PATTERN = re.compile(f"^{_package_name}$", re.IGNORECASE)
 DOTTED_NAME_PATTERN = re.compile(_dotted_name)
-DISPLAY_NAME_PATTERN = re.compile(r"^[^\W_].{2,89}$")
+DISPLAY_NAME_PATTERN = re.compile(r"^[^\W_][\w -~:.'\"]{1,88}[^\W_]$")
 PYTHON_NAME_PATTERN = re.compile(f"^({_dotted_name}):({_dotted_name})$")
 COMMAND_ID_PATTERN = re.compile(
     f"^(({_package_name}\\.)*{_python_identifier})$", re.IGNORECASE
@@ -60,8 +60,9 @@ def python_name(name: str) -> str:
 def display_name(v: str) -> str:
     if not DISPLAY_NAME_PATTERN.match(v):
         raise ValueError(
-            f"{v} is not a valid display_name. It must be 3-90 characters long, and "
-            "must not begin with an underscore, white space, or non-word character."
+            f"{v} is not a valid display_name. It must be 3-40 characters long, "
+            "and must not begin or end with an underscore, white space, or "
+            "non-word character."
         )
     return v
 

--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -60,7 +60,7 @@ def python_name(name: str) -> str:
 def display_name(v: str) -> str:
     if not DISPLAY_NAME_PATTERN.match(v):
         raise ValueError(
-            f"{v} is not a valid display_name. It must be 3-40 characters long, "
+            f"{v} is not a valid display_name. It must be 3-90 characters long, "
             "and must not begin or end with an underscore, white space, or "
             "non-word character."
         )

--- a/npe2/manifest/_validators.py
+++ b/npe2/manifest/_validators.py
@@ -11,6 +11,7 @@ _identifier_plus_dash = "(?:[a-zA-Z_][a-zA-Z_0-9-]+)"
 _dotted_name = f"(?:(?:{_identifier_plus_dash}\\.)*{_identifier_plus_dash})"
 PACKAGE_NAME_PATTERN = re.compile(f"^{_package_name}$", re.IGNORECASE)
 DOTTED_NAME_PATTERN = re.compile(_dotted_name)
+DISPLAY_NAME_PATTERN = re.compile(r"^[^\W_].{1,89}$")
 PYTHON_NAME_PATTERN = re.compile(f"^({_dotted_name}):({_dotted_name})$")
 COMMAND_ID_PATTERN = re.compile(
     f"^(({_package_name}\\.)*{_python_identifier})$", re.IGNORECASE
@@ -57,10 +58,10 @@ def python_name(name: str) -> str:
 
 
 def display_name(v: str) -> str:
-    if not (3 <= len(v) <= 90):
+    if not DISPLAY_NAME_PATTERN.match(v):
         raise ValueError(
-            f"{v} is not a valid display_name.  The display_name must "
-            "be 3-90 characters long."
+            f"{v} is not a valid display_name. It must be 3-90 characters long, and "
+            "must not begin with an underscore, white space, or non-word character."
         )
     return v
 

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -56,8 +56,9 @@ class PluginManifest(ImportExportModel):
     display_name: str = Field(
         "",
         description="User-facing text to display as the name of this plugin. "
-        "Must be 3-90 characters long. If not provided, the manifest `name` will be "
-        "used as the display name.",
+        "Must be 3-90 characters long and must not begin or end with an underscore, "
+        "white space, or non-word character. If not provided, the manifest `name` "
+        "will be used as the display name.",
         min_length=3,
         max_length=90,
     )

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -56,10 +56,10 @@ class PluginManifest(ImportExportModel):
     display_name: str = Field(
         "",
         description="User-facing text to display as the name of this plugin. "
-        "Must be 3-40 characters long, containing printable word characters, "
-        "and must not begin or end with an underscore, white space, or "
-        "non-word character. If not provided, the manifest `name` will be used as the "
-        "display name.",
+        "Must be 3-90 characters long. If not provided, the manifest `name` will be "
+        "used as the display name.",
+        min_length=3,
+        max_length=90,
     )
 
     _validate_display_name = validator("display_name", allow_reuse=True)(

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -173,12 +173,11 @@ def test_valid_mutations(mutator, uses_sample_plugin):
 @pytest.mark.parametrize(
     "display_name",
     [
-        "Here there everywhere and more with giggles and friends",
+        "Here there everywhere and more with giggles and friends on top of a mountainside drinking tea",  # noqa
         "ab",
+        "a   ",
         " abc",
-        "abc ",
         "_abc",
-        "abc_",
         "abc♱",
     ],
 )
@@ -193,6 +192,7 @@ def test_invalid_display_names(display_name, uses_sample_plugin):
     [
         "Some Cell & Stru买cture Segmenter",
         "Segment Blobs and Things with Membranes",
+        "Segment: and Things.2 with Membranes ~= 8",
         "abc",
         "abc䜁䜂",
     ],


### PR DESCRIPTION
The display name validation is too strict, both in terms of length and characters allowed.  It should allow things like colons, periods, etc...  This relaxes it to a string from 3-90 characters, and only restricts the possible values of the first character