### PR TITLE
Add stacklevel to warning.

### DIFF
--- a/npe2/_pytest_plugin.py
+++ b/npe2/_pytest_plugin.py
@@ -16,7 +16,8 @@ class TestPluginManager(PluginManager):
 
         warnings.warn(
             "TestPluginManager is unable to discover plugins. "
-            "Please use `tmp_plugin()` to add a plugin to this plugin manager."
+            "Please use `tmp_plugin()` to add a plugin to this plugin manager.",
+            stacklevel=2
         )
         return 0
 

--- a/npe2/_pytest_plugin.py
+++ b/npe2/_pytest_plugin.py
@@ -17,7 +17,7 @@ class TestPluginManager(PluginManager):
         warnings.warn(
             "TestPluginManager is unable to discover plugins. "
             "Please use `tmp_plugin()` to add a plugin to this plugin manager.",
-            stacklevel=2
+            stacklevel=2,
         )
         return 0
 


### PR DESCRIPTION
With this we can find the caller of this function. Without it we get a generic warning from this function.