### PR TITLE
Fix PackageMetadata validation error with extra provided field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           python -m pip install -e ./napari-from-github
           python -m pip install -e .[json]
           # bare minimum required to test napari/plugins
-          python -m pip install pytest scikit-image[data] zarr xarray hypothesis matplotlib pyside6
+          python -m pip install pytest scikit-image[data] zarr xarray hypothesis matplotlib
 
       - name: Run napari plugin headless tests
         run: pytest -W 'ignore::DeprecationWarning' napari/plugins napari/settings napari/layers napari/components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           python -m pip install -e ./napari-from-github
           python -m pip install -e .[json]
           # bare minimum required to test napari/plugins
-          python -m pip install pytest scikit-image[data] zarr xarray hypothesis matplotlib
+          python -m pip install pytest scikit-image[data] zarr xarray hypothesis matplotlib pyside6
 
       - name: Run napari plugin headless tests
         run: pytest -W 'ignore::DeprecationWarning' napari/plugins napari/settings napari/layers napari/components

--- a/npe2/manifest/_package_metadata.py
+++ b/npe2/manifest/_package_metadata.py
@@ -174,7 +174,11 @@ class PackageMetadata(BaseModel):
     def _validate_root(cls, values):
         if "metadata_version" not in values:
             fields = cls.__fields__
-            mins = {fields[n].field_info.extra.get("min_ver", "1.0") for n in values}
+            mins = {
+                fields[n].field_info.extra.get("min_ver", "1.0")
+                for n in values
+                if n in fields
+            }
             values["metadata_version"] = str(max(float(x) for x in mins))
         return values
 

--- a/tests/test_package_meta.py
+++ b/tests/test_package_meta.py
@@ -17,3 +17,24 @@ def test_package_metadata_version():
 
 def test_hashable():
     hash(PackageMetadata(name="test", version="1.0"))
+
+
+def test_package_metadata_extra_keys():
+    pkg = {
+        "name": "test",
+        "version": "1.0",
+        "maintainer": "bob",
+        "extra_key_that_is_definitely_not_in_the_model": False,
+    }
+
+    try:
+        p = PackageMetadata(**pkg)
+    except Exception:
+        raise AssertionError(
+            "failed to parse PackageMetadata from a dict with an extra key"
+        )
+
+    assert p.name == "test"
+    assert p.version == "1.0"
+    assert p.maintainer == "bob"
+    assert not hasattr(p, "extra_key_that_is_definitely_not_in_the_model")

--- a/tests/test_package_meta.py
+++ b/tests/test_package_meta.py
@@ -19,22 +19,22 @@ def test_hashable():
     hash(PackageMetadata(name="test", version="1.0"))
 
 
-def test_package_metadata_extra_keys():
+def test_package_metadata_extra_field():
     pkg = {
         "name": "test",
         "version": "1.0",
         "maintainer": "bob",
-        "extra_key_that_is_definitely_not_in_the_model": False,
+        "extra_field_that_is_definitely_not_in_the_model": False,
     }
 
     try:
         p = PackageMetadata(**pkg)
     except Exception:
         raise AssertionError(
-            "failed to parse PackageMetadata from a dict with an extra key"
+            "failed to parse PackageMetadata from a dict with an extra field"
         )
 
     assert p.name == "test"
     assert p.version == "1.0"
     assert p.maintainer == "bob"
-    assert not hasattr(p, "extra_key_that_is_definitely_not_in_the_model")
+    assert not hasattr(p, "extra_field_that_is_definitely_not_in_the_model")


### PR DESCRIPTION
The `PackageMetadata` class is configured to ignore extra fields but instantiation can still fail (raises a `KeyError`) when actually provided an extra field due to this custom root validator. Based on the config this does not seem like the intended behavior.

```
class PackageMetadata(BaseModel):
    ....
    class Config:
        extra = Extra.ignore
    ...
    @root_validator(pre=True)
    def _validate_root(cls, values):
        if "metadata_version" not in values:
            fields = cls.__fields__
            mins = {fields[n].field_info.extra.get("min_ver", "1.0") for n in values}
            values["metadata_version"] = str(max(float(x) for x in mins))
        return values
```

This PR just changes that validator skip over any values not in the list of expected fields during this step.