### PR TITLE
Expose `syntax_style`

### DIFF
--- a/_docs/example_manifest.yaml
+++ b/_docs/example_manifest.yaml
@@ -42,6 +42,7 @@ contributions:
     - label: "Monokai"
       id: "monokai"
       type: "dark"
+      syntax_style: "monokai"
       colors:
         canvas: "#000000"
         console: "#000000"
@@ -51,6 +52,7 @@ contributions:
         secondary: "#f8f8f2"
         highlight: "#e6db74"
         text: "#a1ef34"
+        icon: "#a1ef34"
         warning: "#f92672"
         current: "#66d9ef"
   sample_data:

--- a/npe2/manifest/contributions/_themes.py
+++ b/npe2/manifest/contributions/_themes.py
@@ -54,6 +54,7 @@ class ThemeContribution(BaseModel):
         description="Base theme type, used for icons and filling in unprovided colors. "
         "Must be either `'dark'` or  `'light'`."
     )
+    syntax_style: Optional[str]
     colors: ThemeColors = Field(
         description=f"Theme colors. Valid keys include: {_color_keys}. All keys "
         "are optional. Color values can be defined via:\n"

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -75,6 +75,7 @@ contributions:
     - label: "SampleTheme"
       id: "sample_theme"
       type: "dark"
+      syntax_style: "default"
       colors:
         canvas: "#000000"
         console: "#000000"
@@ -84,6 +85,7 @@ contributions:
         secondary: "#f8f8f2"
         highlight: "#e6db74"
         text: "#a1ef34"
+        icon: "#a1ef34"
         warning: "#f92672"
         current: "#66d9ef"
   sample_data:


### PR DESCRIPTION
While working on fixing napari themes (see [this zulip conversation](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/theme.20not.20respected.20in.20qss/near/315705427)) I noticed that some fields that are available in napari are not exposed/tested here: `icon` was unused, and `syntax_style` was not exposed. I added them to the specs and description.

Also, I noticed that if you pass wrong/nonexisting keys, `npe2` does not complain. Is this intended?