### PR TITLE
Update fetch API to improve reliability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     PyYAML
     appdirs
     build
+    packaging
     psygnal>=0.3.0
     pydantic
     pytomlpp


### PR DESCRIPTION
This draft includes two proposed changes:
1. Fetch available plugins via the PyPI XML-RPC API, which is generally much faster and seems more reliable than scraping, but is considered legacy and planned to be deprecated.
2. Fallback on scraping as we do now, but with improved reliability by explicitly setting the ordering to "Date last updated" which results in more stable results.


See #262 for more discussion on whether the first is desirable - I will leave this as draft until that issue is resolved, but I think the second change should be incorporated either way.