### PR TITLE
Fix link to magicgui objects.inv in intersphinx

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,8 +59,8 @@ sphinx:
         - "https://napari-plugin-engine.readthedocs.io/en/latest/"
         - "https://napari-plugin-engine.readthedocs.io/en/latest/objects.inv"
       magicgui:
-        - "https://napari.org/magicgui/"
-        - "https://napari.org/magicgui/objects.inv"
+        - "https://pyapp-kit.github.io/magicgui/"
+        - "https://pyapp-kit.github.io/magicgui/objects.inv"
       napari:
         - "https://napari.org/"
         - "https://napari.org/docs/dev/objects.inv"


### PR DESCRIPTION
Fixes one broken link in the napari documentation.

In `_docs/templates/_npe2_contributions.md.jinja` (which is used to generate https://napari.org/stable/plugins/contributions.html, the lack of correct URL for the magicgui docs inventory file will create a broken link to `magicgui.widgets.Widget` (see https://napari.org/stable/plugins/contributions.html#contributions-widgets)

