### PR TITLE
Bugfix: use .lower() to make paths & pattern fnmatch case  insensitive

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -136,7 +136,8 @@ class _ContributionsIndex:
         assert isinstance(path, str)
 
         # lower case the extension for checking manifest pattern
-        base, ext = os.path.splitext(path)
+        base = os.path.splitext(Path(path).stem)[0]
+        ext = "".join(Path(path).suffixes)
         path = base + ext.lower()
 
         if os.path.isdir(path):

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -140,7 +140,7 @@ class _ContributionsIndex:
             yield from (r for pattern, r in self._readers if pattern == "")
         else:
             # ensure not a URI
-            if urllib.parse.urlparse(path).scheme == "":
+            if not urllib.parse.urlparse(path).scheme:
                 # lower case the extension for checking manifest pattern
                 base = os.path.splitext(Path(path).stem)[0]
                 ext = "".join(Path(path).suffixes)

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -135,6 +135,9 @@ class _ContributionsIndex:
             return
         assert isinstance(path, str)
 
+        # use lower() to make matching case-insensitive
+        path = path.lower()
+
         if os.path.isdir(path):
             yield from (r for pattern, r in self._readers if pattern == "")
         else:
@@ -142,7 +145,8 @@ class _ContributionsIndex:
             # but would we yield duplicate anymore.
             # above does not have have the unseen check either.
             # it's easy to make an iterable version if we wish, or use more-itertools.
-            yield from {r for pattern, r in self._readers if fnmatch(path, pattern)}
+            # match against pattern.lower() to make matching case insensitive
+            yield from {r for pattern, r in self._readers if fnmatch(path, pattern.lower())}
 
     def iter_compatible_writers(
         self, layer_types: Sequence[str]

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -134,10 +134,7 @@ class _ContributionsIndex:
         if not path:
             return
         assert isinstance(path, str)
-
-        # use lower() to make matching case-insensitive
-        path = path.lower()
-
+        
         if os.path.isdir(path):
             yield from (r for pattern, r in self._readers if pattern == "")
         else:

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -135,6 +135,10 @@ class _ContributionsIndex:
             return
         assert isinstance(path, str)
 
+        # lower case the extension for checking manifest pattern
+        base, ext = os.path.splitext(path)
+        path = base + ext.lower()
+
         if os.path.isdir(path):
             yield from (r for pattern, r in self._readers if pattern == "")
         else:

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import urllib
 import warnings
 from collections import Counter
 from fnmatch import fnmatch
@@ -135,14 +136,15 @@ class _ContributionsIndex:
             return
         assert isinstance(path, str)
 
-        # lower case the extension for checking manifest pattern
-        base = os.path.splitext(Path(path).stem)[0]
-        ext = "".join(Path(path).suffixes)
-        path = base + ext.lower()
-
         if os.path.isdir(path):
             yield from (r for pattern, r in self._readers if pattern == "")
         else:
+            # ensure not a URI
+            if urllib.parse.urlparse(path).scheme == "":
+                # lower case the extension for checking manifest pattern
+                base = os.path.splitext(Path(path).stem)[0]
+                ext = "".join(Path(path).suffixes)
+                path = base + ext.lower()
             # not sure about the set logic as it won't be lazy anymore,
             # but would we yield duplicate anymore.
             # above does not have have the unseen check either.

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -134,7 +134,7 @@ class _ContributionsIndex:
         if not path:
             return
         assert isinstance(path, str)
-        
+
         if os.path.isdir(path):
             yield from (r for pattern, r in self._readers if pattern == "")
         else:

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -147,7 +147,9 @@ class _ContributionsIndex:
             # above does not have have the unseen check either.
             # it's easy to make an iterable version if we wish, or use more-itertools.
             # match against pattern.lower() to make matching case insensitive
-            yield from {r for pattern, r in self._readers if fnmatch(path, pattern.lower())}
+            yield from {
+                r for pattern, r in self._readers if fnmatch(path, pattern.lower())
+            }
 
     def iter_compatible_writers(
         self, layer_types: Sequence[str]

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -185,4 +185,4 @@ def test_read_directory_variants(path: str, tmp_path: Path):
         return read
 
     with pytest.raises(ValueError, match="Given path contains capitals."):
-        io_utils._read([path], stack=False, _pm=pm)
+        io_utils._read([str(new_path)], stack=False, _pm=pm)

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -166,7 +166,9 @@ def test_read_tar_gz_variants(path: str):
 
 
 @pytest.mark.parametrize("path", ["some_directory.Final", "some_directory.FINAL"])
-def test_read_directory_variants(path: str):
+def test_read_directory_variants(path: str, tmp_path: Path):
+    new_dir = tmp_path / path 
+    new_dir.mkdir()
     pm = PluginManager()
     plugin = DynamicPlugin("directory-plugin", plugin_manager=pm)
 

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -16,6 +16,19 @@ def test_read_with_unknown_plugin(uses_sample_plugin):
     # no such plugin name.... skips over the sample plugin & error is specific
     with pytest.raises(ValueError, match="Plugin 'nope' was selected"):
         read(["some.fzzy"], plugin_name="nope", stack=False)
+        
+def test_read_uppercase_extension(uses_sample_plugin):
+    # sample plugin hard-codes lower case and returns this error
+    # so the error ensures the matching was case-insensitive
+    # and that the sample plugin received full path (with case)
+    with pytest.raises(ValueError, match="Test plugin should"):
+        read(["some.FZZY"], stack=False)
+
+
+def test_read_with_plugin(uses_sample_plugin):
+    # no such plugin name.... but skips over the sample plugin
+    with pytest.raises(ValueError):
+        read(["some.fzzy"], plugin_name="nope", stack=False)
 
 
 def test_read_with_no_plugin():
@@ -28,6 +41,16 @@ def test_read_return_reader(uses_sample_plugin):
     data, reader = read_get_reader("some.fzzy")
     assert data == [(None,)]
     assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+
+def test_read_uppercase_extension_return_reader(uses_sample_plugin):
+    # sample plugin hard-codes lower case and returns this error
+    # so the error ensures the matching was case-insensitive
+    # and that the sample plugin received full path (with case)
+    with pytest.raises(ValueError, match="Test plugin should"):
+        data, reader = read_get_reader("some.FZZY")
+        assert data == [(None,)]
+        assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 
 def test_read_return_reader_with_stack(uses_sample_plugin):

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -16,7 +16,8 @@ def test_read_with_unknown_plugin(uses_sample_plugin):
     # no such plugin name.... skips over the sample plugin & error is specific
     with pytest.raises(ValueError, match="Plugin 'nope' was selected"):
         read(["some.fzzy"], plugin_name="nope", stack=False)
-        
+
+
 def test_read_uppercase_extension(uses_sample_plugin):
     # sample plugin hard-codes lower case and returns this error
     # so the error ensures the matching was case-insensitive

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -26,12 +26,6 @@ def test_read_uppercase_extension(uses_sample_plugin):
         read(["some.FZZY"], stack=False)
 
 
-def test_read_with_plugin(uses_sample_plugin):
-    # no such plugin name.... but skips over the sample plugin
-    with pytest.raises(ValueError):
-        read(["some.fzzy"], plugin_name="nope", stack=False)
-
-
 def test_read_with_no_plugin():
     # no plugin passed and none registered
     with pytest.raises(ValueError, match="No readers returned"):

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -125,7 +125,7 @@ def test_read_zarr_variants(path: str):
     plugin = DynamicPlugin("zarr-plugin", plugin_manager=pm)
 
     # reader should be compatible despite lowercase pattern
-    @plugin.contribute.reader(filename_patterns=["*.zarr"])
+    @plugin.contribute.reader(filename_patterns=["*.zarr"], accepts_directories=True)
     def get_read(path):
         if path.lower() != path:
             # if this error is raised we can be certain path is unchanged

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -121,7 +121,7 @@ def test_read_uppercase_extension():
     "path", ["some_zarr_directory.ZARR", "some_zarr_directory.Zarr"]
 )
 def test_read_zarr_variants(path: str, tmp_path: Path):
-    new_dir = tmp_path / path 
+    new_dir = tmp_path / path
     new_dir.mkdir()
     pm = PluginManager()
     plugin = DynamicPlugin("zarr-plugin", plugin_manager=pm)
@@ -167,7 +167,7 @@ def test_read_tar_gz_variants(path: str):
 
 @pytest.mark.parametrize("path", ["some_directory.Final", "some_directory.FINAL"])
 def test_read_directory_variants(path: str, tmp_path: Path):
-    new_dir = tmp_path / path 
+    new_dir = tmp_path / path
     new_dir.mkdir()
     pm = PluginManager()
     plugin = DynamicPlugin("directory-plugin", plugin_manager=pm)

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -173,7 +173,7 @@ def test_read_directory_variants(path: str, tmp_path: Path):
     plugin = DynamicPlugin("directory-plugin", plugin_manager=pm)
 
     # reader should be compatible despite lowercase pattern
-    @plugin.contribute.reader(filename_patterns=["*.final"], accepts_directories=True)
+    @plugin.contribute.reader(filename_patterns=["*"], accepts_directories=True)
     def get_read(path):
         if path.lower() != path:
             # if this error is raised we can be certain path is unchanged

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -120,7 +120,9 @@ def test_read_uppercase_extension():
 @pytest.mark.parametrize(
     "path", ["some_zarr_directory.ZARR", "some_zarr_directory.Zarr"]
 )
-def test_read_zarr_variants(path: str):
+def test_read_zarr_variants(path: str, tmp_path: Path):
+    new_dir = tmp_path / path 
+    new_dir.mkdir()
     pm = PluginManager()
     plugin = DynamicPlugin("zarr-plugin", plugin_manager=pm)
 

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -139,7 +139,7 @@ def test_read_zarr_variants(path: str, tmp_path: Path):
         return read
 
     with pytest.raises(ValueError, match="Given path contains capitals."):
-        io_utils._read([path], stack=False, _pm=pm)
+        io_utils._read([str(new_dir)], stack=False, _pm=pm)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
First shot at making the matching of paths to the declared extensions case insensitive.
Closes: https://github.com/napari/napari/issues/5663
Closes https://github.com/napari/npe2/issues/271

@DragaDoncila I'm not sure this is how you had it in mind?
I'm not super familiar with the code base so not sure I'm approaching it the right way vs. just bandaid bugfix.

I added two tests and make fixes to get the tests to pass.
Maybe this is too kludgey...