### PR TITLE
Add specific error when reader plugin was chosen but failed

### DIFF
--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -165,7 +165,7 @@ def _read(
 
     if plugin_name:
         raise ValueError(
-            f"Plugin {plugin_name} was selected to open "
+            f"Plugin {plugin_name!r} was selected to open "
             + f"{paths!r}, but returned no data."
         )
     raise ValueError(f"No readers returned data for {paths!r}")

--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -158,11 +158,9 @@ def _read(
         if plugin_name and not rdr.command.startswith(plugin_name):
             continue
         read_func = rdr.exec(kwargs={"path": paths, "stack": stack})
-        print(read_func)
         if read_func is not None:
             # if the reader function raises an exception here, we don't try to catch it
             if layer_data := read_func(paths, stack=stack):
-                print(layer_data)
                 return (layer_data, rdr) if return_reader else layer_data
 
     if plugin_name:

--- a/npe2/io_utils.py
+++ b/npe2/io_utils.py
@@ -158,10 +158,18 @@ def _read(
         if plugin_name and not rdr.command.startswith(plugin_name):
             continue
         read_func = rdr.exec(kwargs={"path": paths, "stack": stack})
+        print(read_func)
         if read_func is not None:
             # if the reader function raises an exception here, we don't try to catch it
             if layer_data := read_func(paths, stack=stack):
+                print(layer_data)
                 return (layer_data, rdr) if return_reader else layer_data
+
+    if plugin_name:
+        raise ValueError(
+            f"Plugin {plugin_name} was selected to open "
+            + f"{paths!r}, but returned no data."
+        )
     raise ValueError(f"No readers returned data for {paths!r}")
 
 

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -14,7 +14,7 @@ def test_read(uses_sample_plugin):
 
 def test_read_with_unknown_plugin(uses_sample_plugin):
     # no such plugin name.... skips over the sample plugin & error is specific
-    with pytest.raises(ValueError, match="Plugin nope was selected"):
+    with pytest.raises(ValueError, match="Plugin 'nope' was selected"):
         read(["some.fzzy"], plugin_name="nope", stack=False)
 
 

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -12,10 +12,16 @@ def test_read(uses_sample_plugin):
     assert read(["some.fzzy"], stack=False) == [(None,)]
 
 
-def test_read_with_plugin(uses_sample_plugin):
-    # no such plugin name.... but skips over the sample plugin
-    with pytest.raises(ValueError):
+def test_read_with_unknown_plugin(uses_sample_plugin):
+    # no such plugin name.... skips over the sample plugin & error is specific
+    with pytest.raises(ValueError, match="Plugin nope was selected"):
         read(["some.fzzy"], plugin_name="nope", stack=False)
+
+
+def test_read_with_no_plugin():
+    # no plugin passed and none registered
+    with pytest.raises(ValueError, match="No readers returned"):
+        read(["some.nope"], stack=False)
 
 
 def test_read_return_reader(uses_sample_plugin):


### PR DESCRIPTION
Currently we raise the same error in `read` when no layer data is returned by any of the tried readers, regardless of whether a plugin name was given or not. This PR updates the error message to be specific when a `plugin_name` is passed.

This has the added benefit of fixing this [issue](https://github.com/ome/napari-ome-zarr/issues/86) over in `napari-ome-zarr` (which is actually a reincarnation of what napari #4026 was trying to solve) by ensuring the error is re-raised over on the `napari` side. 

I thought about whether a fix should go in `napari` instead, but I think this is the right place to fix this. Over in `napari` we would have to track somehow whether a plugin was tried or not so that we could know whether to continue with `npe1` plugins. But I think if the user chose a plugin, and it failed, `npe2` should alert to that, rather than shuffling it under a general "there were no readers that could read this" error.

Before this PR, running e.g. `napari --plugin napari-ome-zarr ./non-zarr-folder/` gave:

```
Traceback (most recent call last):
  File "/opt/miniconda3/envs/omezarr/bin/napari", line 8, in <module>
    sys.exit(main())
  File "/Users/ddoncilapop/CZI/napari/napari/__main__.py", line 570, in main
    _run()
  File "/Users/ddoncilapop/CZI/napari/napari/__main__.py", line 344, in _run
    viewer._window._qt_viewer._qt_open(
  File "/Users/ddoncilapop/CZI/napari/napari/_qt/qt_viewer.py", line 867, in _qt_open
    self.viewer.open(
  File "/Users/ddoncilapop/CZI/napari/napari/components/viewer_model.py", line 1076, in open
    self._add_layers_with_plugins(
  File "/Users/ddoncilapop/CZI/napari/napari/components/viewer_model.py", line 1276, in _add_layers_with_plugins
    layer_data, hookimpl = read_data_with_plugins(
  File "/Users/ddoncilapop/CZI/napari/napari/plugins/io.py", line 104, in read_data_with_plugins
    raise ValueError(
ValueError: There is no registered plugin named 'napari-ome-zarr'.
```

Whereas now it gives:

```
Traceback (most recent call last):
  File "/opt/miniconda3/envs/omezarr/bin/napari", line 8, in <module>
    sys.exit(main())
  File "/Users/ddoncilapop/CZI/napari/napari/__main__.py", line 570, in main
    _run()
  File "/Users/ddoncilapop/CZI/napari/napari/__main__.py", line 344, in _run
    viewer._window._qt_viewer._qt_open(
  File "/Users/ddoncilapop/CZI/napari/napari/_qt/qt_viewer.py", line 867, in _qt_open
    self.viewer.open(
  File "/Users/ddoncilapop/CZI/napari/napari/components/viewer_model.py", line 1076, in open
    self._add_layers_with_plugins(
  File "/Users/ddoncilapop/CZI/napari/napari/components/viewer_model.py", line 1276, in _add_layers_with_plugins
    layer_data, hookimpl = read_data_with_plugins(
  File "/Users/ddoncilapop/CZI/napari/napari/plugins/io.py", line 77, in read_data_with_plugins
    res = _npe2.read(paths, plugin, stack=stack)
  File "/Users/ddoncilapop/CZI/napari/napari/plugins/_npe2.py", line 61, in read
    raise e from e
  File "/Users/ddoncilapop/CZI/napari/napari/plugins/_npe2.py", line 55, in read
    layer_data, reader = io_utils.read_get_reader(
  File "/Users/ddoncilapop/CZI/npe2/npe2/io_utils.py", line 66, in read_get_reader
    return _read(
  File "/Users/ddoncilapop/CZI/npe2/npe2/io_utils.py", line 167, in _read
    raise ValueError(f"Plugin {plugin_name} was selected to open "+
ValueError: Plugin napari-ome-zarr was selected to open ['./non-zarr-folder/'], but returned no data.
```