### PR TITLE
Fix tests: use npe1 version (0.1.2) of napari-ndtiffs

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -72,7 +72,8 @@ def test_from_pypi_wheel_bdist_missing():
 @pytest.mark.skipif(not os.getenv("CI"), reason="slow, only run on CI")
 def testfetch_manifest_with_full_install():
     # TODO: slowest of the tests ... would be nice to provide a local mock
-    mf = fetch_manifest_with_full_install("napari-ndtiffs")
+    mf = fetch_manifest_with_full_install("napari-ndtiffs", version="0.1.2")
+    # use version 0.1.2 which is npe1
     assert isinstance(mf, NPE1Adapter)
     assert mf.name == "napari-ndtiffs"
     assert mf.contributions


### PR DESCRIPTION
the `testfetch_manifest_with_full_install` in `test_fetch.py` uses `assert isinstance(mf, NPE1Adapter)` for `napari-ndtiffs`:
https://github.com/napari/npe2/blob/d7329b7088f59ac743a67ff47aca32067b5a246a/tests/test_fetch.py#L72-L78
Recently, that plugin was updated to use npe2, so as a result the test fails.
See also discussion starting here: https://github.com/napari/npe2/pull/275#issuecomment-1493137069

This PR passes the `version` argument to use version 0.1.2 of the plugin which is npe1. This is the simple fix to keep the test working as it has.

However, maybe it's best to just drop that NPE1 assert, because I'm not sure it matters that the plugin is or isn't npe1—there are two specific npe1 shim tests already. 
So then here we would only assert the name and contributions.

PS. my OCD wants to fix the name to `test_fetch...` but not sure that's ok? 🤣 

cc: @tlambert03 @Czaki 