### PR TITLE
Pin pydantic bellow 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     appdirs
     build
     psygnal>=0.3.0
-    pydantic
+    pydantic<2
     pytomlpp
     rich
     typer


### PR DESCRIPTION
Pin pydantic to be bellow 2.0 as we know that current npe2 code is incompatible with pydatnic 