### PR TITLE
fix: use logger instead of warning for TestPluginManager.discover

### DIFF
--- a/src/npe2/_pytest_plugin.py
+++ b/src/npe2/_pytest_plugin.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 from typing import Optional, Union
 from unittest.mock import patch
@@ -6,18 +7,17 @@ import pytest
 
 from npe2 import DynamicPlugin, PluginManager, PluginManifest
 
+logger = logging.getLogger(__name__)
+
 
 class TestPluginManager(PluginManager):
     """A PluginManager subclass suitable for use in testing."""
 
     def discover(self, *_, **__) -> int:
         """Discovery is blocked in the TestPluginManager."""
-        import warnings
-
-        warnings.warn(
-            "TestPluginManager is unable to discover plugins. "
-            "Please use `tmp_plugin()` to add a plugin to this plugin manager.",
-            stacklevel=2,
+        logger.warning(
+            "NOTE: TestPluginManager refusing to discover plugins. "
+            "You may add plugins to this test plugin manager using `tmp_plugin()`."
         )
         return 0
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,9 +14,11 @@ def test_something_1(npe2pm):
 CASE2 = """
 import pytest
 
-def test_something_2(npe2pm):
-    with pytest.warns(UserWarning, match='unable to discover plugins'):
-        npe2pm.discover()
+def test_something_2(npe2pm, caplog):
+    npe2pm.discover()
+    assert "TestPluginManager refusing to discover plugins" in caplog.text
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
 """
 
 CASE3 = """


### PR DESCRIPTION
the stacklevel=2 on the `TestPluginManager` from the last precommit update is causing unnecessary warnings in the napari tests.  This converts it to a logging.warning.