### PR TITLE
fix: pass command registry to rdr.exec in io_utils._read

### DIFF
--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -157,7 +157,9 @@ def _read(
     for rdr in _pm.iter_compatible_readers(paths):
         if plugin_name and not rdr.command.startswith(plugin_name):
             continue
-        read_func = rdr.exec(kwargs={"path": paths, "stack": stack})
+        read_func = rdr.exec(
+            kwargs={"path": paths, "stack": stack, "_registry": _pm.commands}
+        )
         if read_func is not None:
             # if the reader function raises an exception here, we don't try to catch it
             if layer_data := read_func(paths, stack=stack):

--- a/src/npe2/manifest/utils.py
+++ b/src/npe2/manifest/utils.py
@@ -59,7 +59,8 @@ class Executable(GenericModel, Generic[R]):
     ) -> R:
         if kwargs is None:
             kwargs = {}
-        return self.get_callable(_registry)(*args, **kwargs)
+        reg = _registry or kwargs.pop("_registry", None)
+        return self.get_callable(reg)(*args, **kwargs)
 
     def get_callable(
         self,

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -2,7 +2,15 @@
 
 import pytest
 
-from npe2 import read, read_get_reader, write, write_get_writer
+from npe2 import (
+    DynamicPlugin,
+    PluginManager,
+    io_utils,
+    read,
+    read_get_reader,
+    write,
+    write_get_writer,
+)
 from npe2.types import FullLayerData
 
 SAMPLE_PLUGIN_NAME = "my-plugin"
@@ -72,3 +80,17 @@ def test_writer_single_layer_api_exec(uses_sample_plugin):
     # This writer doesn't do anything but type check.
     paths = write("test/path", [([], {}, "labels")])
     assert len(paths) == 1
+
+
+def test_read_non_global_pm():
+    pm = PluginManager()
+    plugin = DynamicPlugin("my-plugin", plugin_manager=pm)
+
+    @plugin.contribute.reader
+    def read_path(path):
+        def _reader(path):
+            return [(None,)]
+
+        return _reader
+
+    assert io_utils._read(["some.fzzy"], stack=False, _pm=pm) == [(None,)]


### PR DESCRIPTION
this fixes an issue wherein `npe2.read` doesn't find a command registered with a non-global PluginManager instance