### PR TITLE
Change ArrayLike type to use read only properties

### DIFF
--- a/src/npe2/types.py
+++ b/src/npe2/types.py
@@ -30,13 +30,16 @@ PythonName = NewType("PythonName", str)
 
 class ArrayLike(Protocol):
     @property
-    def shape(self) -> Tuple[int, ...]: ...
+    def shape(self) -> Tuple[int, ...]:
+        ...
 
     @property
-    def ndim(self) -> int: ...
+    def ndim(self) -> int:
+        ...
 
     @property
-    def dtype(self) -> "np.dtype": ...
+    def dtype(self) -> "np.dtype":
+        ...
 
     def __array__(self) -> "np.ndarray":
         ...  # pragma: no cover


### PR DESCRIPTION
# Description

The `np.ndarray` type does not seem to satisfy the `ArrayLike` type. This PR fixes that by using read-only properties instead of plain settable attributes.

Here's a simple reproducer for mypy.

```python
import numpy as np
from npe2.types import ArrayLike

a: np.ndarray = np.array([])

def foo(b: ArrayLike) -> None:
    print(b)

foo(a)
```

For me, mypy fails before this change, but passes afterwards. Let me know if there's a way to add some form of this to automated tests/CI.

# Context

I encountered this while writing a plugin where I'm aiming for full(ish) typing coverage. I understand the `ArrayLike` type has other problems with respect to some napari layer data types (which have their own problems), but it seems like it should at least be satisfied by `np.ndarray`. This is also more consistent with [napari's layer data protocol](https://github.com/napari/napari/blob/46dcc9c0976c35ec9dc64be60235f4addcadaa5c/napari/layers/_data_protocols.py#L71).