### PR TITLE
fix: use constraints in napari tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ./napari-from-github
+          python -m pip install -e ./napari-from-github -c "./napari-from-github/resources/constraints/constraints_py3.10.txt"
           python -m pip install -e .[json]
           # bare minimum required to test napari/plugins
           python -m pip install pytest scikit-image[data] zarr xarray hypothesis matplotlib


### PR DESCRIPTION
Workaround for problem with napari-svg problem pointed in #297.

The original bug is in repository as `("0", "1", "6") > ("0", "1", "10")` - the wrong code for version comparison. 