### PR TITLE
DOCS: Widget guide should consistently use parent=None kwarg in examples

### DIFF
--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -30,8 +30,8 @@ specification:
    from qtpy.QtWidgets import QWidget
 
    class MyPluginWidget(QWidget):
-       def __init__(self, viewer: 'napari.viewer.Viewer'):
-           super().__init__()
+       def __init__(self, viewer: 'napari.viewer.Viewer', parent=None):
+           super().__init__(parent)
            self._viewer = viewer
    ```
 


### PR DESCRIPTION
Closes https://github.com/napari/docs/issues/186 and prevents leaking widgets in cases where widgets remain floating (undocked)