### PR TITLE
Fix invalid JSON Schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,9 @@ jobs:
       - name: Build schema
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[docs]
+          pip install -e .[docs] check-jsonschema
           python -m npe2.manifest.schema > _schema.json
+          check-jsonschema --check-metaschema _schema.json
       - name: Test rendering docs
         run: python _docs/render.py
         env:
@@ -122,8 +123,9 @@ jobs:
 
       - name: write schema
         run: |
-          pip install -e .
+          pip install -e . check-jsonschema
           python -m npe2.manifest.schema > schema.json
+          check-jsonschema --check-metaschema schema.json
 
       - name: Build and publish
         run: twine upload dist/*

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -21,8 +21,8 @@ __all__ = [
 ]
 
 JsonType = Literal["array", "boolean", "integer", "null", "number", "object", "string"]
-JsonTypeArray = conlist(JsonType, min_items=True, unique_items=True)
-StringArrayMin1 = conlist(str, unique_items=True, min_items=1)
+JsonTypeArray = conlist(JsonType, min_items=1, unique_items=True)
+StringArrayMin1 = conlist(str, min_items=1, unique_items=True)
 StringArray = conlist(str, unique_items=True)
 
 PY_NAME_TO_JSON_NAME = {


### PR DESCRIPTION
This fixes an [issue reported on Zulip](https://napari.zulipchat.com/#narrow/stream/309872-plugins/topic/napari.20plugin.20manifest.20schema/near/386669802) by @seankmartin. Basically there was a small error in the generated manifest json schema:

```
❯ check-jsonschema --check-metaschema _schema.json
Schema validation errors were encountered.
  _schema.json::$.definitions.ConfigurationProperty.properties.type.anyOf[1].minItems: True is not of type 'integer'
  _schema.json::$.definitions.Draft06JsonSchema.properties.type.anyOf[1].minItems: True is not of type 'integer'
  _schema.json::$.definitions.Draft07JsonSchema.properties.type.anyOf[1].minItems: True is not of type 'integer'
```

The root of the problem is here, where `min_items` is set to `True` instead of an integer.
https://github.com/napari/npe2/blob/80ca5feb501dd25d36ecf1313f94d80366d25b8e/src/npe2/manifest/contributions/_json_schema.py#L24C3-L24C3

The first commit here adds a check of the schema in CI using [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema). Then the second commit should fix the underlying issue.

cc: @nclack 