### PR TITLE
DOC Update and clarify supported widget contributions

### DIFF
--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -17,14 +17,17 @@ specifically requested by the user.
 ```
 
 The widget specification requires that the plugin provide napari with a
-*callable* object that, when called, returns an *instance* of a widget
-(where a "widget" is an instance of `QtWidgets.QWidget` or `magicgui.widgets.Widget`).
+*callable* object that, when called, returns an *instance* of a widget.
+Here "widget" means a subclass of `QtWidgets.QWidget` or `magicgui.widgets.Widget`,
+or a `FunctionGui`. Additionally, the plugin can provide an arbitrary function if using
+'autogenerate', which requests that napari autogenerate a widget using
+`magicgui.magicgui` (see item 3 below).
 
 There are a few commonly used patterns that fulfill this `Callable[..., Widget]`
 specification:
 
-1. Provide a `class` object directly, such as a `QtWidgets.QWidget` or
-   `magicgui.widgets.Widget` subclass:
+1. Provide a `class` object that is a subclass of `QtWidgets.QWidget` or
+   `magicgui.widgets.Widget`:
 
    ```python
    from qtpy.QtWidgets import QWidget
@@ -35,7 +38,7 @@ specification:
            self._viewer = viewer
    ```
 
-2. Provide a wrapper function, or `magicgui.magic_factory` object:
+2. Provide a `magicgui.magic_factory` object:
 
     ```python
     from magicgui import magic_factory


### PR DESCRIPTION
This PR:

* Clarifies that the only supported widget parent classes are `QtWidgets.QWidget` or `magicgui.widgets.Widget`. The "such as" suggested that other parent classes could be supported
* Removes documented support for wrapper functions - going forward we do not want to support wrapper functions. (I.e. we do not want new plugins to use wrappers). it is difficult to type (both the wrapper, which will just be a normal function, and the return object, which could be many things) and is too flexible and difficult maintain.
    * I think we want to be backwards compatible but this is outside the scope of this PR and should be discussed in: https://github.com/napari/napari/issues/6174 

Context - this was noted as part of the menu contributions work (https://github.com/napari/napari/issues/6174)