### PR TITLE
update url for fetching plugin listing from napari hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "PyYAML",
     "appdirs",
-    "build",
+    "build>=1",
     "psygnal>=0.3.0",
     "pydantic<2",
     "tomli-w",

--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -41,7 +41,6 @@ __all__ = [
     "fetch_manifest",
     "get_pypi_url",
     "get_hub_plugin",
-    "get_hub_plugins",
     "get_pypi_plugins",
 ]
 

--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -408,7 +408,7 @@ def get_pypi_plugins() -> Dict[str, str]:
 @lru_cache
 def get_hub_plugins() -> Dict[str, str]:
     """Return {name: latest_version} for all plugins on the hub."""
-    with request.urlopen("https://api.napari-hub.org/plugins") as r:
+    with request.urlopen("https://api.napari-hub.org/plugins/index/all") as r:
         return json.load(r)
 
 

--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -406,13 +406,6 @@ def get_pypi_plugins() -> Dict[str, str]:
 
 
 @lru_cache
-def get_hub_plugins() -> Dict[str, str]:
-    """Return {name: latest_version} for all plugins on the hub."""
-    with request.urlopen("https://api.napari-hub.org/plugins/index/all") as r:
-        return json.load(r)
-
-
-@lru_cache
 def get_hub_plugin(plugin_name: str) -> Dict[str, Any]:
     """Return hub information for a specific plugin."""
     with request.urlopen(f"https://api.napari-hub.org/plugins/{plugin_name}") as r:

--- a/src/npe2/_inspection/_full_install.py
+++ b/src/npe2/_inspection/_full_install.py
@@ -58,9 +58,9 @@ def isolated_plugin_env(
     """
     # it's important that this import be lazy, otherwise we'll get a circular
     # import when serving as a setuptools plugin with `python -m build`
-    from build.env import IsolatedEnvBuilder
+    from build.env import DefaultIsolatedEnv
 
-    with IsolatedEnvBuilder() as env:
+    with DefaultIsolatedEnv() as env:
         # install the package
         pkg = f"{package}=={version}" if version else package
         logger.debug(f"installing {pkg} into virtual env")

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -93,11 +93,6 @@ def test_get_manifest_from_wheel(tmp_path):
     assert mf.name == "affinder"
 
 
-def test_get_hub_plugins():
-    plugins = get_hub_plugins()
-    assert len(plugins) > 0
-
-
 def test_get_hub_plugin():
     info = get_hub_plugin("napari-svg")
     assert info["name"] == "napari-svg"

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -9,7 +9,6 @@ from npe2 import PluginManifest, fetch_manifest
 from npe2._inspection._fetch import (
     _manifest_from_pypi_sdist,
     get_hub_plugin,
-    get_hub_plugins,
     get_manifest_from_wheel,
     get_pypi_plugins,
     get_pypi_url,


### PR DESCRIPTION
This PR updates for a couple api changes in dependencies that are blocking #311 and #312.

For the napar-hub api, the `/plugins` endpoint was removed (see [here](https://github.com/chanzuckerberg/napari-hub/discussions/1065)). This impacts the `get_hub_plugins()` function, and a test `test_get_hub_plugins` which fails without this change. It doesn't appear that anything actually uses these, so this PR removes them.

Also [build](https://github.com/pypa/build) updated to 1.0. `IsolatedEnvBuilder` was renamed to `DefaultIsolatedEnv`.