### PR TITLE
Use concurency for canceling workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request: {}
   workflow_dispatch:
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-manifest:
     name: Check Manifest

--- a/.github/workflows/test_all_plugins.yml
+++ b/.github/workflows/test_all_plugins.yml
@@ -14,9 +14,6 @@ jobs:
     if: github.event.label.name == 'test-all-plugins' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
       - id: plugin_names
         run: echo "::set-output name=plugins::$(curl -s https://api.napari-hub.org/plugins | jq -c 'keys')"
     outputs:

--- a/.github/workflows/test_all_plugins.yml
+++ b/.github/workflows/test_all_plugins.yml
@@ -5,6 +5,10 @@ on:
     types: [ labeled ]
   workflow_dispatch:
 
+concurrency:
+  group: test-plugins-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-plugins:
     if: github.event.label.name == 'test-all-plugins' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/test_conversion.yml
+++ b/.github/workflows/test_conversion.yml
@@ -5,13 +5,14 @@ on:
   # pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: convert-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-plugins:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
       - id: plugin_names
         run: echo "::set-output name=plugins::$(curl -s https://api.napari-hub.org/plugins | jq -c 'keys')"
     outputs:


### PR DESCRIPTION
Stop using `styfle/cancel-workflow-action` and use the builtin concurrency feature. 