### PR TITLE
Catch errors and log in `_dispose` in `PluginContext`

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -7,6 +7,7 @@ import warnings
 from collections import Counter
 from fnmatch import fnmatch
 from importlib import metadata
+from logging import getLogger
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -51,6 +52,8 @@ if TYPE_CHECKING:
     MappingIntStrAny = Mapping[IntStr, Any]
     InclusionSet = Union[AbstractSetIntStr, MappingIntStrAny, None]
     DisposeFunction = Callable[[], None]
+
+logger = getLogger(__name__)
 
 __all__ = ["PluginContext", "PluginManager"]
 PluginName = str  # this is `PluginManifest.name`
@@ -710,7 +713,10 @@ class PluginContext:
 
     def _dispose(self):
         while self._disposables:
-            self._disposables.pop()()
+            try:
+                self._disposables.pop()()
+            except Exception as e:
+                logger.warn(f'Error while disposing {self.plugin_key}; {e}')
 
     def register_command(self, id: str, command: Optional[Callable] = None):
         """Associate a callable with a command id."""


### PR DESCRIPTION
When running the dispose functions in `_dispose` in `PluginContext`, catch errors and log instead of raising.

Suggested by Talley in: https://github.com/pyapp-kit/app-model/issues/147#issuecomment-1803898923