### PR TITLE
Add constraint for brainreg-segment in test

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -49,7 +49,6 @@ def test_fetch_npe1_manifest_dock_widget_as_attribute():
     mf = fetch_manifest("brainreg-segment", version="0.2.18")
     assert mf.name == "brainreg-segment"
     assert mf.contributions.widgets
-    # Test will eventually fail when brainreg-segment is updated to npe2
     # This is here as a sentinel
     assert mf.npe1_shim is True
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -46,7 +46,7 @@ def test_fetch_npe1_manifest_dock_widget_as_attribute():
     # napari_experimental_provide_dock_widget parser, (where the return value
     # is a dotted attribute, rather than a direct name).  I only saw it in
     # brainreg-segment.
-    mf = fetch_manifest("brainreg-segment")
+    mf = fetch_manifest("brainreg-segment", version="0.2.18")
     assert mf.name == "brainreg-segment"
     assert mf.contributions.widgets
     # Test will eventually fail when brainreg-segment is updated to npe2


### PR DESCRIPTION
It looks like brainreg-segment in version 0.2.19 switch to be npe2 plugin
