### PR TITLE
DOC Add cross references to widget contributions

### DIFF
--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -61,6 +61,11 @@ specification:
    hook specification.  In the new `npe2` pattern, one uses the `autogenerate`
    field in the [WidgetContribution](contributions-widgets).
 
+For more examples see [](creating-widgets) and
+[GUI gallery examples](https://napari.org/stable/_tags/gui.html) (only a subset
+involve widgets). Additionally,
+[cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin)
+has more robust widget examples that you can adapt to your needs.
 
 ### Widget example
 

--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -1,8 +1,11 @@
 (widgets-contribution-guide)=
 ## Widgets
 
-Widget plugins allow developers to contribute novel graphical
-elements (aka "widgets") to the user interface.  These widgets can request
+Widget plugin contributions allow developers to add novel graphical
+elements (aka "widgets") to the user interface. For a full introduction to
+creating `napari` widgets see [](creating-widgets).
+
+Widgets can request
 access to the viewer instance in which they are docked, enabling a broad
 range of functionality: essentially, anything that can be done with the
 napari `Viewer` and `Layer` APIs can be accomplished with widgets.


### PR DESCRIPTION
Depends on https://github.com/napari/docs/pull/286 

Adds references to new 'creating widgets' section and gallery and cookiecutter to widget contributions page.