### PR TITLE
Add permisions to deploy steep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
     needs: test
     if: "success() && startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pr fixes the bug of 403 error during create github release:

```
Run softprops/action-gh-release@v1
👩‍🏭 Creating new GitHub release for tag v0.7.4...
⚠️ GitHub release failed with status: 403
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.7.4...
⚠️ GitHub release failed with status: 403
undefined
retrying... (1 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.7.4...
⚠️ GitHub release failed with status: 403
undefined
retrying... (0 retries remaining)
❌ Too many retries. Aborting...
Error: Too many retries.
```

https://github.com/softprops/action-gh-release/issues/400#issuecomment-1869045218

I have added also `id-token: write` because this is set of permissions that we have in the main repository. 