### PR TITLE
TST Fix `test_conversion_missing`

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -141,14 +141,16 @@ setup(
 
 def test_conversion_missing():
     with pytest.raises(
-        PackageNotFoundError, match="No package or entry point found with name",
+        PackageNotFoundError,
+        match="No package or entry point found with name",
     ):
         manifest_from_npe1("does-not-exist-asdf6as987")
 
 
 def test_conversion_package_is_not_a_plugin():
     with pytest.raises(
-        PackageNotFoundError, match="No package or entry point found with name",
+        PackageNotFoundError,
+        match="No package or entry point found with name",
     ):
         manifest_from_npe1("pytest")
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -140,12 +140,16 @@ setup(
 
 
 def test_conversion_missing():
-    with pytest.raises(ModuleNotFoundError), pytest.warns(UserWarning):
+    with pytest.raises(
+        PackageNotFoundError, match="No package or entry point found with name",
+    ):
         manifest_from_npe1("does-not-exist-asdf6as987")
 
 
 def test_conversion_package_is_not_a_plugin():
-    with pytest.raises(PackageNotFoundError):
+    with pytest.raises(
+        PackageNotFoundError, match="No package or entry point found with name",
+    ):
         manifest_from_npe1("pytest")
 
 


### PR DESCRIPTION
This test is failing in CIs in #340.

I think it is because there is no warning raised (not sure why the `UserWarning` is there). It used to pass because of this bug in pytest https://github.com/pytest-dev/pytest/issues/9036, but this was fixed in https://github.com/pytest-dev/pytest/pull/11129 and included in a recent release, thus our CIs are failing. 

Note that I have update the test to be more specific about the exception raised (`PackageNotFoundError`) but it is not needed, subclass exceptions are still accepted by pytest. Also added a message to be more specific.