### PR TITLE
allow v2.3 in metadataversion, fallback to any string

### DIFF
--- a/src/npe2/manifest/_package_metadata.py
+++ b/src/npe2/manifest/_package_metadata.py
@@ -32,7 +32,7 @@ class PackageMetadata(BaseModel):
 
     # allow str as a fallback in case the metata-version specification has been
     # updated and we haven't updated the code yet
-    metadata_version: MetadataVersion | str = Field(
+    metadata_version: Union[MetadataVersion, str] = Field(
         "1.0", description="Version of the file format"
     )
     name: PackageName = Field(  # type: ignore

--- a/src/npe2/manifest/_package_metadata.py
+++ b/src/npe2/manifest/_package_metadata.py
@@ -12,7 +12,7 @@ from npe2._pydantic_compat import (
 
 # https://packaging.python.org/specifications/core-metadata/
 
-MetadataVersion = Literal["1.0", "1.1", "1.2", "2.0", "2.1", "2.2"]
+MetadataVersion = Literal["1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"]
 _alphanum = "[a-zA-Z0-9]"
 PackageName = constr(regex=f"^{_alphanum}[a-zA-Z0-9._-]*{_alphanum}$")
 
@@ -30,7 +30,9 @@ class PackageMetadata(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    metadata_version: MetadataVersion = Field(
+    # allow str as a fallback in case the metata-version specification has been
+    # updated and we haven't updated the code yet
+    metadata_version: MetadataVersion | str = Field(
         "1.0", description="Version of the file format"
     )
     name: PackageName = Field(  # type: ignore


### PR DESCRIPTION
someone recently showed me an issue validating the manifest of a napari plugin, 

```
ValidationError: 1 validation error for PackageMetadata
metadata_version
  unexpected value; permitted: '1.0', '1.1', '1.2', '2.0', '2.1', '2.2' (type=value_error.const; given=2.3; permitted=('1.0', '1.1', '1.2', '2.0', '2.1', '2.2'))
```

What happened is that PEP685 https://peps.python.org/pep-0685/ added a new spec (v2.3), and some build backends have begun to implement it.  For example, hatchling (which this package was using) bumped their default version to v2.3 5 days ago: https://github.com/pypa/hatch/commit/1a9c30dace7e811656a09b5a3ad0e03d62fb25de

This PR just relaxes the validation of metadata_version to allow for any string.  

@napari/core-devs, this is something that would be important to get in soon and push a new release.  Packages that use setuptools will not have this issue, but anything using hatchling after [1.22.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.22.1) (released on Mar 15) will begin to see this