### PR TITLE
DOC Add note on string type annotations in widget contributions

### DIFF
--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -58,6 +58,10 @@ specification:
    hook specification.  In the new `npe2` pattern, one uses the `autogenerate`
    field in the [WidgetContribution](contributions-widgets).
 
+```{note}
+Notice that `napari` type annotations are strings and not imported. This is to
+avoid including `napari` as a plugin dependency when not strictly required.
+```
 
 ### Widget example
 


### PR DESCRIPTION
Add note that type annotations should be str to avoid having `napari` as dependency