### PR TITLE
Add dictionary mapping `command_id` to its associated `MenuCommand`s for each plugin

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -623,7 +623,7 @@ class PluginManager:
         for mf in self.iter_manifests(disabled=disabled):
             yield from mf.contributions.menus.get(menu_key, ())
 
-    def menus(self, disabled=False) -> Dict[str, List[MenuCommand]]:
+    def menus(self, disabled=False) -> Dict[str, List[MenuItem]]:
         """Return all registered menu_key -> List[MenuItems]."""
         _menus: DefaultDict[str, List[MenuItem]] = DefaultDict(list)
         for mf in self.iter_manifests(disabled=disabled):

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -367,9 +367,7 @@ class PluginManager:
 
     def _populate_command_menu_map(self, manifest: PluginManifest):
         # map of manifest -> command -> menu_id -> list[items]
-        self._command_menu_map[manifest.name] = defaultdict(
-            lambda: defaultdict(list)
-        )
+        self._command_menu_map[manifest.name] = defaultdict(lambda: defaultdict(list))
         menu_map = self._command_menu_map[manifest.name]  # just for conciseness below
         for menu_id, menu_items in manifest.contributions.menus.items() or ():
             # command IDs are keys in map

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -366,6 +366,7 @@ class PluginManager:
         self.events.plugins_registered.emit({manifest})
 
     def _populate_command_menu_map(self, manifest: PluginManifest):
+        self._command_menu_map[manifest.name] = defaultdict(dict)
         for command in manifest.contributions.commands or ():
             # command IDs are keys in map
             # each value is a dict menu_id: list of MenuCommands
@@ -473,6 +474,7 @@ class PluginManager:
         mf = self._manifests.get(plugin_name)
         if mf is not None:
             self._contrib.index_contributions(mf)
+            self._populate_command_menu_map(mf)
         self.events.enablement_changed({plugin_name}, {})
 
     def disable(self, plugin_name: PluginName) -> None:
@@ -492,6 +494,7 @@ class PluginManager:
 
         self._disabled_plugins.add(plugin_name)
         self._contrib.remove_contributions(plugin_name)
+        self._command_menu_map.pop(plugin_name)
         self.events.enablement_changed({}, {plugin_name})
 
     def is_disabled(self, plugin_name: str) -> bool:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -236,3 +236,33 @@ def test_plugin_context_dispose_error(caplog):
     pm.get_context("test").register_disposable(dummy_error)
     pm.deactivate("test")
     assert caplog.records[0].msg == "Error while disposing test; This is an error"
+
+
+def test_command_menu_map(uses_sample_plugin, plugin_manager: PluginManager):
+    """Test that the command menu map is correctly populated."""
+    pm = PluginManager.instance()
+    assert SAMPLE_PLUGIN_NAME in pm._manifests
+    assert SAMPLE_PLUGIN_NAME in pm._command_menu_map
+
+    # contains correct commands
+    command_menu_map = pm._command_menu_map[SAMPLE_PLUGIN_NAME]
+    assert "my-plugin.hello_world" in command_menu_map
+    assert "my-plugin.another_command" in command_menu_map
+
+    # commands point to correct menus
+    assert len(cmd_menu := command_menu_map["my-plugin.hello_world"]) == 1
+    assert "/napari/layer_context" in cmd_menu
+    assert len(cmd_menu := command_menu_map["my-plugin.another_command"]) == 1
+    assert "mysubmenu" in cmd_menu
+
+    # enable/disable
+    pm.disable(SAMPLE_PLUGIN_NAME)
+    assert SAMPLE_PLUGIN_NAME not in pm._command_menu_map
+    pm.enable(SAMPLE_PLUGIN_NAME)
+    assert SAMPLE_PLUGIN_NAME in pm._command_menu_map
+
+    # register/unregister
+    pm.unregister(SAMPLE_PLUGIN_NAME)
+    assert SAMPLE_PLUGIN_NAME not in pm._command_menu_map
+    pm.register(SAMPLE_PLUGIN_NAME)
+    assert SAMPLE_PLUGIN_NAME in pm._command_menu_map


### PR DESCRIPTION
Adding this dictionary to support quick mapping of widgets/commands to their menus for implementing contributable menus . Prior to this PR, you would have to search all menu contributions for the command of the contribution you were currently processing. This map allows you direct access to the menus this command needs to live in. 

This is a precursor to potentially rearchitecting the manifest schema entirely to be "command-first".