### PR TITLE
On disable, dont try to pop a key that doesn't exist

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -486,7 +486,7 @@ class PluginManager:
 
         self._disabled_plugins.add(plugin_name)
         self._contrib.remove_contributions(plugin_name)
-        self._command_menu_map.pop(plugin_name)
+        self._command_menu_map.pop(plugin_name, None)
         self.events.enablement_changed({}, {plugin_name})
 
     def is_disabled(self, plugin_name: str) -> bool:


### PR DESCRIPTION
Closes https://github.com/napari/napari/issues/7135

This is a naive fix. If the key doesn't exist when disabling, just return None.