### PR TITLE
Change type of layer Metadata from Dict to Mapping

### DIFF
--- a/src/npe2/types.py
+++ b/src/npe2/types.py
@@ -2,7 +2,6 @@ from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     List,
     Literal,
     NewType,

--- a/src/npe2/types.py
+++ b/src/npe2/types.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -48,7 +49,7 @@ class ArrayLike(Protocol):
 LayerName = Literal[
     "graph", "image", "labels", "points", "shapes", "surface", "tracks", "vectors"
 ]
-Metadata = Dict
+Metadata = Mapping
 DataType = Union[ArrayLike, Sequence[ArrayLike]]
 FullLayerData = Tuple[DataType, Metadata, LayerName]
 LayerData = Union[Tuple[DataType], Tuple[DataType, Metadata], FullLayerData]


### PR DESCRIPTION
We should accept any `Mapping` object as valid metadata. 

Implement https://napari.zulipchat.com/#narrow/stream/212875-general/topic/DeprecatingDict.20not.20accepted.20in.20LayerDataTuple/near/468436819