### PR TITLE
Update widgets guide to point to napari-plugin-template

### DIFF
--- a/_docs/templates/_npe2_widgets_guide.md.jinja
+++ b/_docs/templates/_npe2_widgets_guide.md.jinja
@@ -64,7 +64,7 @@ specification:
 For more examples see [](creating-widgets) and
 [GUI gallery examples](https://napari.org/stable/_tags/gui.html) (only a subset
 involve widgets). Additionally,
-[cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin)
+[napari-plugin-template](https://github.com/napari/napari-plugin-template)
 has more robust widget examples that you can adapt to your needs.
 
 ```{note}


### PR DESCRIPTION
Remove mention of cookiecutter-napari-plugin from the widget guide.