### PR TITLE
Change npe1 plugin used for sample data test

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -36,7 +36,7 @@ def test_fetch_npe1_manifest_with_sample_data():
     mf = fetch_manifest("napari-kics")
     assert mf.name == "napari-kics"
     assert mf.contributions.sample_data
-    # Test will eventually fail when napari-pyclesperanto-assistant is updated to npe2
+    # Test will eventually fail when napari-kics is updated to npe2
     # This is here as a sentinel
     assert mf.npe1_shim is True
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -33,8 +33,8 @@ def test_fetch_npe1_manifest_with_writer():
 
 
 def test_fetch_npe1_manifest_with_sample_data():
-    mf = fetch_manifest("napari-pyclesperanto-assistant")
-    assert mf.name == "napari-pyclesperanto-assistant"
+    mf = fetch_manifest("napari-kics")
+    assert mf.name == "napari-kics"
     assert mf.contributions.sample_data
     # Test will eventually fail when napari-pyclesperanto-assistant is updated to npe2
     # This is here as a sentinel


### PR DESCRIPTION
Closes #363 by changing the plugin used in the test to avoid name normalization issues entirely.