### PR TITLE
Tolerate distributions with no Name

### DIFF
--- a/src/npe2/manifest/utils.py
+++ b/src/npe2/manifest/utils.py
@@ -81,7 +81,13 @@ class Executable(GenericModel, Generic[R]):
 
             # look for a package name in the command id
             dists = sorted(
-                (d.metadata["Name"] for d in distributions()), key=len, reverse=True
+                (
+                    d.metadata["Name"]
+                    for d in distributions()
+                    if d.metadata["Name"] is not None
+                ),
+                key=len,
+                reverse=True,
             )
             for name in dists:
                 if self.command.startswith(name):  # pragma: no cover


### PR DESCRIPTION
https://bugs.debian.org/1090247 shows a napari test failure caused by this on Python 3.13.  On closer inspection I found that `/usr/lib/python3.13/dist-packages/coverage-7.6.0.egg-info` and `/usr/lib/python3.13/dist-packages/tqdm-4.67.1.dist-info` existed with no `Name` metadata field.  This shouldn't cause a failure here.