### PR TITLE
Add utility for retrieving the name of all shimmed plugins

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -715,6 +715,10 @@ class PluginManager:
         # Nothing got found
         return None, path
 
+    def get_shimmed_plugins(self) -> List[str]:
+        """Return a list of all shimmed plugin names."""
+        return [mf.name for mf in self.iter_manifests() if mf.npe1_shim]
+
 
 class PluginContext:
     """An object that can contain information for a plugin over its lifetime."""

--- a/src/npe2/plugin_manager.py
+++ b/src/npe2/plugin_manager.py
@@ -129,6 +129,10 @@ def get_writer(
     """Get Writer contribution appropriate for `path`, and `layer_types`."""
 
 
+def get_shimmed_plugins() -> List[str]:
+    """Return a list of all shimmed plugin names."""
+
+
 def _populate_module():
     """Convert all functions in this module into global plugin manager methods."""
     import functools

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -268,3 +268,11 @@ def test_command_menu_map(uses_sample_plugin, plugin_manager: PluginManager):
     assert SAMPLE_PLUGIN_NAME not in pm._command_menu_map
     pm.register(SAMPLE_PLUGIN_NAME)
     assert SAMPLE_PLUGIN_NAME in pm._command_menu_map
+
+
+def test_get_shimmed_plugins(pm: PluginManager, uses_npe1_plugin):
+    assert len(pm.get_shimmed_plugins()) == 0
+    pm.discover(include_npe1=True)
+    shimmed = pm.get_shimmed_plugins()
+    assert len(shimmed) == 1
+    assert shimmed[0] == "npe1-plugin"


### PR DESCRIPTION
Adds a simple utility that iterates through all discovered plugins and returns the names of all plugins that are shimmed from `npe1` i.e. don't have their own manifest, but have an `npe1` entrypoint.