### PR TITLE
Clarify that sample data contributions must return valid layer data

### DIFF
--- a/_docs/templates/_npe2_sample_data_guide.md.jinja
+++ b/_docs/templates/_npe2_sample_data_guide.md.jinja
@@ -10,6 +10,10 @@ It can take the form of a **Sample Data URI** that points to a static resource
 (such as a file included in the plugin distribution, or a remote resource),
 or **Sample Data Function** that generates layer data on demand.
 
+Note that unlike reader contributions, sample data contributions are
+**always** expected to return data, so returning `[(None,)]`
+will cause an error.
+
 ### Sample Data example
 
 ::::{tab-set}

--- a/src/npe2/manifest/contributions/_sample_data.py
+++ b/src/npe2/manifest/contributions/_sample_data.py
@@ -32,7 +32,9 @@ class SampleDataGenerator(_SampleDataContribution, Executable[List[LayerData]]):
     """Contribute a callable command that creates data on demand."""
 
     command: str = Field(
-        ..., description="Identifier of a command that returns layer data tuple."
+        ...,
+        description="Identifier of a command that returns layer data tuple. "
+        "Note that this command cannot return `[(None,)]`.",
     )
 
     def open(


### PR DESCRIPTION
Follow on from [napari/#7851](https://github.com/napari/napari/pull/7851) I thought we should clarify that sample contributions are expected to always return valid layer data, unlike readers which can return the null layer sentinel. 

Note we'll need to resolve #378 for CI to pass.