### PR TITLE
Update code and tests to address manifest failure

### DIFF
--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -14,12 +14,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ContextManager,
-    Dict,
     Iterator,
-    List,
     Optional,
     Union,
-    Tuple,
 )
 from unittest.mock import patch
 from urllib import error, request

--- a/src/npe2/_inspection/_from_npe1.py
+++ b/src/npe2/_inspection/_from_npe1.py
@@ -90,7 +90,7 @@ def plugin_packages() -> List[PackageInfo]:
     packages: List[PackageInfo] = []
     for dist in metadata.distributions():
         packages.extend(
-            PackageInfo(package_name=dist.metadata["Name"], entry_points=[ep])
+            PackageInfo(package_name=dist.metadata.get("Name", "unknown"), entry_points=[ep])
             for ep in dist.entry_points
             if ep.group == NPE1_EP
         )
@@ -144,7 +144,7 @@ def manifest_from_npe1(
         # don't use isinstance(Distribution), setuptools monkeypatches sys.meta_path:
         # https://github.com/pypa/setuptools/issues/3169
         NPE1_ENTRY_POINT = "napari.plugin"
-        plugin_name = package_name = plugin.metadata["Name"]
+        plugin_name = package_name = plugin.metadata.get("Name", "unknown")
         modules = [
             ep.value for ep in plugin.entry_points if ep.group == NPE1_ENTRY_POINT
         ]

--- a/src/npe2/_inspection/_visitors.py
+++ b/src/npe2/_inspection/_visitors.py
@@ -421,7 +421,7 @@ def find_npe1_module_contributions(
     ContributionPoints
         ContributionPoints discovered in the module.
     """
-    plugin_name = dist.metadata["Name"]
+    plugin_name = dist.metadata.get("Name", "unknown")
     file = _locate_module_in_dist(dist, module_name)
     visitor = NPE1PluginModuleVisitor(plugin_name, module_name=module_name)
     visitor.visit(ast.parse(Path(file).read_text()))

--- a/src/npe2/manifest/_npe1_adapter.py
+++ b/src/npe2/manifest/_npe1_adapter.py
@@ -78,7 +78,9 @@ class NPE1Adapter(PluginManifest):
         """_summary_"""
         meta = PackageMetadata.from_dist_metadata(dist.metadata)
         super().__init__(
-            name=dist.metadata["Name"], package_metadata=meta, npe1_shim=True
+            name=dist.metadata.get("Name", "unknown"),
+            package_metadata=meta,
+            npe1_shim=True,
         )
         self._dist = dist
 

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -368,15 +368,15 @@ class PluginManifest(ImportExportModel):
                     logger.warning(
                         "Invalid schema for package %r, please run"
                         " 'npe2 validate %s' to check for manifest errors.",
-                        dist.metadata["Name"],
-                        dist.metadata["Name"],
+                        dist.metadata.get("Name", "unknown"),
+                        dist.metadata.get("Name", "unknown"),
                     )
                     yield DiscoverResults(None, dist, e)
 
                 except Exception as e:
                     logger.error(
                         "{} -> {!r} could not be imported: {}".format(
-                            ENTRY_POINT, dist.metadata["Name"], e
+                            ENTRY_POINT, dist.metadata.get("Name", "unknown"), e
                         )
                     )
                     yield DiscoverResults(None, dist, e)

--- a/src/npe2/manifest/utils.py
+++ b/src/npe2/manifest/utils.py
@@ -82,9 +82,9 @@ class Executable(GenericModel, Generic[R]):
             # look for a package name in the command id
             dists = sorted(
                 (
-                    d.metadata["Name"]
+                    d.metadata.get("Name")
                     for d in distributions()
-                    if d.metadata["Name"] is not None
+                    if d.metadata.get("Name") is not None
                 ),
                 key=len,
                 reverse=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_cli_parse(sample_path, format, tmp_path, to_file):
 @pytest.mark.parametrize("to_file", [True, False])
 @pytest.mark.parametrize("include_meta", [True, False])
 def test_cli_fetch(format, tmp_path, to_file, include_meta):
-    cmd = ["fetch", "napari-omero"]
+    cmd = ["fetch", "napari-ndev"]
     if to_file:
         dest = tmp_path / f"output.{format}"
         cmd.extend(["-o", str(dest)])
@@ -87,7 +87,7 @@ def test_cli_fetch(format, tmp_path, to_file, include_meta):
         assert dest.exists()
         assert PluginManifest.from_file(dest)
     else:
-        assert "napari-omero" in result.stdout  # just prints the yaml
+        assert "napari-ndev" in result.stdout  # just prints the yaml
         if include_meta:
             assert "package_metadata" in result.stdout
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -15,8 +15,8 @@ from npe2._inspection._fetch import (
 
 
 def test_fetch_npe2_manifest():
-    mf = fetch_manifest("napari-omero")
-    assert mf.name == "napari-omero"
+    mf = fetch_manifest("napari-ndev")
+    assert mf.name == "napari-ndev"
     assert any(mf.contributions.dict().values())
     assert mf.npe1_shim is False
 


### PR DESCRIPTION
Closes #378 

This PR adds a distinct error for `PackageNotFound`. It also puts some code into try blocks to be more robust, and adds a fallback value of "unknown" when a match is not found to prevent implicit checks of None.