### PR TITLE
Fix error box displayed when CLI launched with no options

### DIFF
--- a/src/npe2/cli.py
+++ b/src/npe2/cli.py
@@ -11,7 +11,11 @@ from npe2 import PluginManager, PluginManifest, __version__
 if TYPE_CHECKING:
     from rich.console import RenderableType
 
-app = typer.Typer(no_args_is_help=True)
+app = typer.Typer(
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    rich_markup_mode="rich",
+)
 
 
 def _show_version_and_exit(value: bool) -> None:
@@ -498,4 +502,10 @@ def compile(
 
 
 def main():
+    import sys
+
+    # If no arguments provided, show help without error box
+    if len(sys.argv) == 1:
+        sys.argv.append("--help")
+
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,3 +212,12 @@ def test_cli_version():
 def test_compile(compiled_plugin_dir):
     result = runner.invoke(app, ["compile", str(compiled_plugin_dir)])
     assert "id: my_compiled_plugin.my-plugin.generate_random_data" in result.output
+
+
+def test_main_no_args_shows_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["npe2"])
+    with pytest.raises(SystemExit) as e:
+        main()
+    assert e.value.code == 0
+    captured = capsys.readouterr()
+    assert "Usage:" in captured.out or "Usage:" in captured.err


### PR DESCRIPTION
This PR fixes the error box being displayed when running `npe2` without any command line options.

**Before**
![Screenshot 2025-07-04 at 10 25 09 AM](https://github.com/user-attachments/assets/0c040302-3f50-42fd-8656-ca3509242380)

**After**
![Screenshot 2025-07-04 at 10 25 35 AM](https://github.com/user-attachments/assets/e0e0a922-df57-4890-8b4d-610c8905e233)
