### PR TITLE
Add test for get manifest from zip and improve logic to recurse the zip to find manifest

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -93,10 +93,7 @@ def test_get_hub_plugin():
         "https://files.pythonhosted.org/packages/5d/ae/17779e12ce60d8329306963e1a8dec608465caee582440011ff0c1310715/example_plugin-0.0.7-py3-none-any.whl",
         "git+https://github.com/napari/dummy-test-plugin.git@npe1",
         # this one doesn't use setuptools_scm, can check direct zip without clone
-        # FIXME: skipping this test as it is failing due to a setuptools update
-        # see https://github.com/napari/npe2/issues/378
-        # we should update this test to use a different plugin
-        # "https://github.com/jo-mueller/napari-stl-exporter/archive/refs/heads/main.zip",
+        "https://github.com/jo-mueller/napari-stl-exporter/archive/refs/heads/main.zip",
     ],
 )
 def test_fetch_urls(url):


### PR DESCRIPTION
This PR tests the function and brings coverage back to green.

  The test uses mocks and verifies that `_get_manifest_from_zip_url`:
  - Properly uses the context manager
  - Correctly finds the first directory inside the extracted path
  - Passes that directory to the build function and returns its result

This PR modifies the `_get_manifest_from_zip_url` to recurse the zip beyond the first directory to look for the manifest. Keeps the original approach as a fallback if searching the zip does not find a manifest.