### PR TITLE
Show menus and submenus in the contributions page

### DIFF
--- a/_docs/render.py
+++ b/_docs/render.py
@@ -182,13 +182,15 @@ def main(dest: Path = _BUILD):
     env.filters["has_guide"] = has_guide
 
     dest.mkdir(exist_ok=True, parents=True)
-    schema = PluginManifest.schema()
     if local_schema := os.getenv("NPE2_SCHEMA"):
         with open(local_schema) as f:
             schema = json.load(f)
     else:
-        with urlopen(SCHEMA_URL) as response:
-            schema = json.load(response)
+        try:
+            schema = PluginManifest.schema()
+        except Exception:
+            with urlopen(SCHEMA_URL) as response:
+                schema = json.load(response)
 
     contributions = schema["definitions"]["ContributionPoints"]["properties"]
     context = {

--- a/_docs/templates/_npe2_contributions.md.jinja
+++ b/_docs/templates/_npe2_contributions.md.jinja
@@ -21,10 +21,21 @@ is being discussed.
 (contributions-{{ contrib_name|replace('_', '-') }})=
 ## `contributions.{{contrib_name}}`
 {# check if this is a single type, or a union #}
-{%- if contrib['items']['anyOf'] is defined %}
+{%- if contrib.type == 'object' and contrib.additionalProperties is defined %}
+{# Handle object types like menus #}
+{%- if contrib['additionalProperties']['items']['anyOf'] is defined %}
+{%- set type_names = contrib['additionalProperties']['items']['anyOf']|map(attribute='$ref')|map("replace", "#/definitions/", "")|list  %}
+{%- set union = True %}
+{%- else %}
+{%- set type_names = [contrib['additionalProperties']['items']['$ref']|replace("#/definitions/", "")] %}
+{%- set union = False %}
+{%- endif -%}
+{%- elif contrib['items']['anyOf'] is defined %}
+{# Handle array types with union #}
 {%- set type_names = contrib['items']['anyOf']|map(attribute='$ref')|map("replace", "#/definitions/", "")|list  %}
 {%- set union = True %}
 {%- else %}
+{# Handle array types with single type #}
 {%- set type_names = [contrib['items']['$ref']|replace("#/definitions/", "")] %}
 {%- set union = False %}
 {%- endif -%}
@@ -34,10 +45,17 @@ This contribution accepts {{ type_names|length }} schema types
 ```
 {%- endif -%}
 
+{%- if contrib.type == 'object' and contrib.additionalProperties is defined %}
+{# For object types like menus, use the contribution description directly #}
+{{ contrib.description }}
+{%- endif %}
+
 {%- for tname in type_names -%}
 {% set type = schema['definitions'][tname] %}
 {% if union %}##### {{loop.index}}. {{type.title}}{% endif %}
+{%- if contrib.type != 'object' or contrib.additionalProperties is not defined %}
 {{ type.description }}
+{%- endif %}
 
 {% if contrib_name|has_guide %}
 See the [{{ contrib_name.title()|replace('_', ' ') }} Guide]({{ contrib_name|replace('_', '-') }}-contribution-guide)

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -38,10 +38,10 @@ class ContributionPoints(BaseModel):
     themes: Optional[List[ThemeContribution]]
     menus: Dict[str, List[MenuItem]] = Field(
         default_factory=dict,
-        description="Contributes menu items to existing napari menus."
-        "Menu items can be commands, e.g. opening a widget, or additional submenus."
-        "This allows you to create nested hierarchies within napari menus, enabling"
-        "you to organize your plugin's contributions within the menu structure.",
+        description="Add menu items to existing napari menus."
+        "A menu item can be a command, such as open a widget, or a submenu."
+        "Using menu items, nested hierarchies can be created within napari menus."
+        "This allows you to organize your plugin's contributions within napari's menu structure.",
     )
     submenus: Optional[List[SubmenuContribution]]
     keybindings: Optional[List[KeyBindingContribution]] = Field(None, hide_docs=True)

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -36,8 +36,13 @@ class ContributionPoints(BaseModel):
     widgets: Optional[List[WidgetContribution]]
     sample_data: Optional[List[SampleDataContribution]]
     themes: Optional[List[ThemeContribution]]
-    menus: Dict[str, List[MenuItem]] = Field(default_factory=dict, hide_docs=True)
-    submenus: Optional[List[SubmenuContribution]] = Field(None, hide_docs=True)
+    menus: Dict[str, List[MenuItem]] = Field(
+        default_factory=dict,
+        description="Contributes menu items to existing napari menus.",
+    )
+    submenus: Optional[List[SubmenuContribution]] = Field(
+        None, description="Contributes submenus that can be referenced by menu items."
+    )
     keybindings: Optional[List[KeyBindingContribution]] = Field(None, hide_docs=True)
 
     configuration: List[ConfigurationContribution] = Field(

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -40,9 +40,7 @@ class ContributionPoints(BaseModel):
         default_factory=dict,
         description="Contributes menu items to existing napari menus.",
     )
-    submenus: Optional[List[SubmenuContribution]] = Field(
-        None, description="Contributes submenus that can be referenced by menu items."
-    )
+    submenus: Optional[List[SubmenuContribution]]
     keybindings: Optional[List[KeyBindingContribution]] = Field(None, hide_docs=True)
 
     configuration: List[ConfigurationContribution] = Field(

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -38,7 +38,10 @@ class ContributionPoints(BaseModel):
     themes: Optional[List[ThemeContribution]]
     menus: Dict[str, List[MenuItem]] = Field(
         default_factory=dict,
-        description="Contributes menu items to existing napari menus.",
+        description="Contributes menu items to existing napari menus."
+        "Menu items can be commands, e.g. opening a widget, or additional submenus."
+        "This allows you to create nested hierarchies within napari menus, enabling"
+        "you to organize your plugin's contributions within the menu structure.",
     )
     submenus: Optional[List[SubmenuContribution]]
     keybindings: Optional[List[KeyBindingContribution]] = Field(None, hide_docs=True)

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -41,7 +41,7 @@ class ContributionPoints(BaseModel):
         description="Add menu items to existing napari menus."
         "A menu item can be a command, such as open a widget, or a submenu."
         "Using menu items, nested hierarchies can be created within napari menus."
-        "This allows you to organize your plugin's contributions within",
+        "This allows you to organize your plugin's contributions within"
         "napari's menu structure.",
     )
     submenus: Optional[List[SubmenuContribution]]

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -41,7 +41,8 @@ class ContributionPoints(BaseModel):
         description="Add menu items to existing napari menus."
         "A menu item can be a command, such as open a widget, or a submenu."
         "Using menu items, nested hierarchies can be created within napari menus."
-        "This allows you to organize your plugin's contributions within napari's menu structure.",
+        "This allows you to organize your plugin's contributions within",
+        "napari's menu structure.",
     )
     submenus: Optional[List[SubmenuContribution]]
     keybindings: Optional[List[KeyBindingContribution]] = Field(None, hide_docs=True)

--- a/src/npe2/manifest/contributions/_submenu.py
+++ b/src/npe2/manifest/contributions/_submenu.py
@@ -6,6 +6,13 @@ from ._icon import Icon
 
 
 class SubmenuContribution(BaseModel):
+    """Contributes a submenu that can contain menu items or other submenus.
+
+    Submenus allow you to organize menu items into hierarchical structures.
+    Each submenu defines an id, label, and optional icon that can be
+    referenced by menu items to create nested menu structures.
+    """
+
     id: str = Field(description="Identifier of the menu to display as a submenu.")
     label: str = Field(
         description="The label of the menu item which leads to this submenu."


### PR DESCRIPTION
Ok, this is a replacement for https://github.com/napari/npe2/pull/387
Instead of whack a mole I tried to go from the start looking at the schema.json (release in this repo)
```
"menus": {
          "title": "Menus",
          "hide_docs": true,
          "type": "object",
          "additionalProperties": {
            "type": "array",
            "items": {
              "anyOf": [
                {
                  "$ref": "#/definitions/MenuCommand"
                },
                {
                  "$ref": "#/definitions/Submenu"
                }
              ]
            }
          }
        },
        "submenus": {
          "title": "Submenus",
          "hide_docs": true,
          "type": "array",
          "items": {
            "$ref": "#/definitions/SubmenuContribution"
          }
        },
```
If you compare to some of the others:
```
        "readers": {
          "title": "Readers",
          "type": "array",
          "items": {
            "$ref": "#/definitions/ReaderContribution"
          }
        },
        "writers": {
          "title": "Writers",
          "type": "array",
          "items": {
            "$ref": "#/definitions/WriterContribution"
          }
        },
        "widgets": {
          "title": "Widgets",
          "type": "array",
          "items": {
            "$ref": "#/definitions/WidgetContribution"
          }
        },
```
So then it becomes more clear how to modify the template. i did get a bit of help from Claude.
Also, I was working locally and had some issues with the schema.json coming from the release, so hide kept being set.
I tweaked render.py to use local schema, which got things working for me.

Let's see if CI likes it!