### PR TITLE
Relax codecov to 98%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,4 @@ coverage:
   status:
     project:
       default:
-        target: 100%
+        target: 98%


### PR DESCRIPTION
While we are actively working on this repo, let's relax coverage to 98%. This will make it easier to determine when CI tests are green vs. minor coverage changes.

cc/ @psobolewskiPhD @DragaDoncila 