### PR TITLE
Remove napari-hub API function and tests

### DIFF
--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -12,9 +12,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Any,
     ContextManager,
-    Dict,
     Iterator,
     List,
     Optional,
@@ -36,7 +34,6 @@ NPE1_ENTRY_POINT = "napari.plugin"
 NPE2_ENTRY_POINT = "napari.manifest"
 __all__ = [
     "fetch_manifest",
-    "get_hub_plugin",
     "get_pypi_url",
 ]
 
@@ -409,10 +406,3 @@ def _tmp_pypi_sdist_download(
     url = get_pypi_url(package, version=version, packagetype="sdist")
     logger.debug(f"downloading sdist for {package} {version or ''}")
     return _tmp_targz_download(url)
-
-
-@lru_cache
-def get_hub_plugin(plugin_name: str) -> Dict[str, Any]:
-    """Return hub information for a specific plugin."""
-    with request.urlopen(f"https://api.napari-hub.org/plugins/{plugin_name}") as r:
-        return json.load(r)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -9,7 +9,6 @@ from npe2 import PluginManifest, fetch_manifest
 from npe2._inspection._fetch import (
     _get_manifest_from_zip_url,
     _manifest_from_pypi_sdist,
-    get_hub_plugin,
     get_manifest_from_wheel,
     get_pypi_url,
 )
@@ -78,11 +77,6 @@ def test_get_manifest_from_wheel(tmp_path):
     urllib.request.urlretrieve(url, dest)
     mf = get_manifest_from_wheel(dest)
     assert mf.name == "affinder"
-
-
-def test_get_hub_plugin():
-    info = get_hub_plugin("napari-svg")
-    assert info["name"] == "napari-svg"
 
 
 @pytest.mark.skipif(not os.getenv("CI"), reason="slow, only run on CI")


### PR DESCRIPTION
Since we've transferred the napari hub to our implementation, `api.napari-hub.org` is no longer available. All plugin information is available via `npe2api`.