### PR TITLE
Resolve deprecation warning in docs build

### DIFF
--- a/_docs/render.py
+++ b/_docs/render.py
@@ -186,7 +186,7 @@ def main(dest: Path = _BUILD):
             schema = json.load(f)
     else:
         try:
-            schema = PluginManifest.schema()
+            schema = PluginManifest.model_json_shema()
         except Exception:
             with urlopen(SCHEMA_URL) as response:
                 schema = json.load(response)


### PR DESCRIPTION
Docs build for napari contains such warning. 

```
/home/circleci/project/docs/npe2/_docs/render.py:189: PydanticDeprecatedSince20: The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
  schema = PluginManifest.schema()
```

This PR resolve it. 