### PR TITLE
chore: fix pydantic constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "platformdirs",
     "build>=1",
     "psygnal>=0.3.0",
-    "pydantic>1",
+    "pydantic>2",
     "pydantic_extra_types",
     "tomli-w",
     "tomli; python_version < '3.11'",


### PR DESCRIPTION
Our release 0.8.0 improperly claims that it works with pydantic 1. 

This PR fixes this by bumping the version in dependencies. 

Then we should release 0.8.1 and yank 0.8.0 from pypi. 