### PR TITLE
Unify icon contributions and clarify supported formats

### DIFF
--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -1,7 +1,5 @@
 import re
 
-from npe2.manifest.contributions._icon import Icon
-
 _package_name = "([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])"
 _python_identifier = "([a-zA-Z_][a-zA-Z_0-9]*)"
 
@@ -66,24 +64,4 @@ def display_name(v: str) -> str:
             "and must not begin or end with an underscore, white space, or "
             "non-word character."
         )
-    return v
-
-
-def icon_path(v: str | Icon | None) -> str | Icon | None:
-    if isinstance(v, str) and v.startswith("http"):
-        if not v.startswith("https://"):
-            raise ValueError(
-                f"{v} is not a valid icon URL. It must start with 'https://'"
-            )
-    if isinstance(v, Icon):
-        if v.light is not None and v.light.startswith("http"):
-            if not v.light.startswith("https://"):
-                raise ValueError(
-                    f"{v.light} is not a valid icon URL. It must start with 'https://'"
-                )
-        if v.dark is not None and v.dark.startswith("http"):
-            if not v.dark.startswith("https://"):
-                raise ValueError(
-                    f"{v.dark} is not a valid icon URL. It must start with 'https://'"
-                )
     return v

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -65,3 +65,25 @@ def display_name(v: str) -> str:
             "non-word character."
         )
     return v
+
+
+def coerce_icon(cls, value):
+    if value is None:
+        return None
+    if isinstance(value, str) and value.startswith("http"):
+        if not value.startswith("https://"):
+            raise ValueError(
+                f"{value} is not a valid icon URL. It must start with 'https://'"
+            )
+    # aftervalidator, so it's guaranteed to be of type Icon
+    if value.light is not None and value.light.startswith("http"):
+        if not value.light.startswith("https://"):
+            raise ValueError(
+                f"{value.light} is not a valid icon URL. It must start with 'https://'"
+            )
+    if value.dark is not None and value.dark.startswith("http"):
+        if not value.dark.startswith("https://"):
+            raise ValueError(
+                f"{value.dark} is not a valid icon URL. It must start with 'https://'"
+            )
+    return value

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -1,5 +1,7 @@
 import re
 
+from npe2.manifest.contributions._icon import Icon
+
 _package_name = "([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])"
 _python_identifier = "([a-zA-Z_][a-zA-Z_0-9]*)"
 
@@ -67,14 +69,21 @@ def display_name(v: str) -> str:
     return v
 
 
-def icon_path(v: str) -> str:
-    if not v:
-        return ""
-    if v.startswith("http"):
+def icon_path(v: str | Icon | None) -> str | Icon | None:
+    if isinstance(v, str) and v.startswith("http"):
         if not v.startswith("https://"):
             raise ValueError(
                 f"{v} is not a valid icon URL. It must start with 'https://'"
             )
-        return v
-    assert isinstance(v, str), f"{v} must be a string"
+    if isinstance(v, Icon):
+        if v.light is not None and v.light.startswith("http"):
+            if not v.light.startswith("https://"):
+                raise ValueError(
+                    f"{v.light} is not a valid icon URL. It must start with 'https://'"
+                )
+        if v.dark is not None and v.dark.startswith("http"):
+            if not v.dark.startswith("https://"):
+                raise ValueError(
+                    f"{v.dark} is not a valid icon URL. It must start with 'https://'"
+                )
     return v

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -67,24 +67,20 @@ def display_name(v: str) -> str:
     return v
 
 
+def _ensure_valid_https(value):
+    if value.startswith("http") and not value.startswith("https://"):
+        raise ValueError(
+            f"{value} is not a valid icon URL. It must start with 'https://'"
+        )
+
+
 def coerce_icon(value):
     if value is None:
         return None
-    if isinstance(value, str) and value.startswith("http"):
-        if not value.startswith("https://"):
-            raise ValueError(
-                f"{value} is not a valid icon URL. It must start with 'https://'"
-            )
-        return value
-    # aftervalidator, so it's guaranteed to be of type Icon
-    if value.light is not None and value.light.startswith("http"):
-        if not value.light.startswith("https://"):
-            raise ValueError(
-                f"{value.light} is not a valid icon URL. It must start with 'https://'"
-            )
-    if value.dark is not None and value.dark.startswith("http"):
-        if not value.dark.startswith("https://"):
-            raise ValueError(
-                f"{value.dark} is not a valid icon URL. It must start with 'https://'"
-            )
+    if isinstance(value, str):
+        _ensure_valid_https(value)
+    if light_url := getattr(value, "light", None):
+        _ensure_valid_https(light_url)
+    if dark_url := getattr(value, "dark", None):
+        _ensure_valid_https(dark_url)
     return value

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -67,7 +67,7 @@ def display_name(v: str) -> str:
     return v
 
 
-def coerce_icon(cls, value):
+def coerce_icon(value):
     if value is None:
         return None
     if isinstance(value, str) and value.startswith("http"):
@@ -75,6 +75,7 @@ def coerce_icon(cls, value):
             raise ValueError(
                 f"{value} is not a valid icon URL. It must start with 'https://'"
             )
+        return value
     # aftervalidator, so it's guaranteed to be of type Icon
     if value.light is not None and value.light.startswith("http"):
         if not value.light.startswith("https://"):

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -67,20 +67,24 @@ def display_name(v: str) -> str:
     return v
 
 
-def _ensure_valid_https(value):
-    if value.startswith("http") and not value.startswith("https://"):
+def _ensure_valid_resource(value):
+    if ":" not in value:
         raise ValueError(
-            f"{value} is not a valid icon URL. It must start with 'https://'"
+            f"{value} is not a valid path in the form `package:resource`, "
+            "where `package` and `resource` are arguments to "
+            "`importlib.resources.path(package, resource)` "
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+            "shipped with the sdist)"
         )
 
 
-def coerce_icon(value):
+def validate_icon(value):
     if value is None:
         return None
     if isinstance(value, str):
-        _ensure_valid_https(value)
-    if light_url := getattr(value, "light", None):
-        _ensure_valid_https(light_url)
-    if dark_url := getattr(value, "dark", None):
-        _ensure_valid_https(dark_url)
+        _ensure_valid_resource(value)
+    if light_url := getattr(value, "light", None) is not None:
+        _ensure_valid_resource(light_url)
+    if dark_url := getattr(value, "dark", None) is not None:
+        _ensure_valid_resource(dark_url)
     return value

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -68,10 +68,10 @@ def display_name(v: str) -> str:
 
 
 def _ensure_valid_resource(value):
-    if ":" not in value:
+    if "/" in value or (value.count(":") != 1 and value.count(".") != 1):
         raise ValueError(
-            f"{value} is not a valid path in the form `package:resource`, "
-            "where `package` and `resource` are arguments to "
+            f"{value} is not a valid fonticon or iconify key, nor a path in the form "
+            "`package:resource`, where `package` and `resource` are arguments to "
             "`importlib.resources.path(package, resource)` "
             "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
             "shipped with the sdist)"

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -83,8 +83,8 @@ def validate_icon(value):
         return None
     if isinstance(value, str):
         _ensure_valid_resource(value)
-    if light_url := getattr(value, "light", None) is not None:
+    if light_url := getattr(value, "light", None):
         _ensure_valid_resource(light_url)
-    if dark_url := getattr(value, "dark", None) is not None:
+    if dark_url := getattr(value, "dark", None):
         _ensure_valid_resource(dark_url)
     return value

--- a/src/npe2/manifest/contributions/_commands.py
+++ b/src/npe2/manifest/contributions/_commands.py
@@ -71,7 +71,7 @@ class CommandContribution(BaseModel):
         None,
         description="Category string by which the command may be grouped in the UI.",
     )
-    icon: str | Icon | None = Field(
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.coerce_icon)] = Field(
         None,
         description="Icon used to represent this command in the UI, on"
         " buttons or in menus. Can be a single string or two different options"

--- a/src/npe2/manifest/contributions/_commands.py
+++ b/src/npe2/manifest/contributions/_commands.py
@@ -73,11 +73,18 @@ class CommandContribution(BaseModel):
     )
     icon: str | Icon | None = Field(
         None,
-        description="Icon used to represent this command in the UI, on "
-        "buttons or in menus. These may be [superqt](https://github.com/napari/superqt)"
-        " fonticon keys, such as `'fa6s.arrow_down'`; though note that plugins are "
-        "expected to depend on any fonticon libraries they use, e.g "
-        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6).",
+        description="Icon used to represent this command in the UI, on"
+        " buttons or in menus. Can be a single string or two different options"
+        " for light and dark themes. These values may be:"
+        "<ul><li> a secure (https) URL </li>"
+        "<li>a string in the format `{package}:{resource}`, where `package` and "
+        "`resource` are arguments to `importlib.resources.files(package, resource)` "
+        "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+        "shipped with the sdist)"
+        "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
+        "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
+        "any fonticon libraries they use, e.g "
+        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
     )
     enablement: str | None = Field(
         None,

--- a/src/npe2/manifest/contributions/_commands.py
+++ b/src/npe2/manifest/contributions/_commands.py
@@ -78,7 +78,7 @@ class CommandContribution(BaseModel):
         " for light and dark themes. These values may be:"
         "<ul><li> a secure (https) URL </li>"
         "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.files(package, resource)` "
+        "`resource` are arguments to `importlib.resources.path(package, resource)` "
         "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
         "shipped with the sdist)"
         "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "

--- a/src/npe2/manifest/contributions/_commands.py
+++ b/src/npe2/manifest/contributions/_commands.py
@@ -71,20 +71,21 @@ class CommandContribution(BaseModel):
         None,
         description="Category string by which the command may be grouped in the UI.",
     )
-    icon: Annotated[str | Icon | None, AfterValidator(_validators.coerce_icon)] = Field(
-        None,
-        description="Icon used to represent this command in the UI, on"
-        " buttons or in menus. Can be a single string or two different options"
-        " for light and dark themes. These values may be:"
-        "<ul><li> a secure (https) URL </li>"
-        "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.path(package, resource)` "
-        "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
-        "shipped with the sdist)"
-        "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
-        "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
-        "any fonticon libraries they use, e.g "
-        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.validate_icon)] = (
+        Field(
+            None,
+            description="Icon used to represent this command in the UI, on"
+            " buttons or in menus. Can be a single string or two different options"
+            " for light and dark themes. These values may be:"
+            "<li>a string in the format `{package}:{resource}`, where `package` and "
+            "`resource` are arguments to `importlib.resources.path(package, resource)` "
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+            "shipped with the sdist)"
+            "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
+            "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
+            "any fonticon libraries they use, e.g "
+            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+        )
     )
     enablement: str | None = Field(
         None,

--- a/src/npe2/manifest/contributions/_commands.py
+++ b/src/npe2/manifest/contributions/_commands.py
@@ -74,17 +74,17 @@ class CommandContribution(BaseModel):
     icon: Annotated[str | Icon | None, AfterValidator(_validators.validate_icon)] = (
         Field(
             None,
-            description="Icon used to represent this command in the UI, on"
-            " buttons or in menus. Can be a single string or two different options"
-            " for light and dark themes. These values may be:"
-            "<li>a string in the format `{package}:{resource}`, where `package` and "
+            description="Icon used to represent this command in the UI, on "
+            "buttons or in menus. Can be a single string or two different options "
+            "for light and dark themes. These values may be:"
+            "<ul><li>a string in format `{package}:{resource}`, where `package` and"
             "`resource` are arguments to `importlib.resources.path(package, resource)` "
-            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
-            "shipped with the sdist)"
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be shipped"
+            "with the wheel, e.g. via the `package-data` entry in pyproject.toml)"
             "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
             "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
-            "any fonticon libraries they use, e.g "
-            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+            "any fonticon libraries they use, e.g. "
+            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))",
         )
     )
     enablement: str | None = Field(

--- a/src/npe2/manifest/contributions/_submenu.py
+++ b/src/npe2/manifest/contributions/_submenu.py
@@ -17,9 +17,16 @@ class SubmenuContribution(BaseModel):
     )
     icon: str | Icon | None = Field(
         None,
-        description=(
-            "(Optional) Icon which is used to represent the command in the UI."
-            " Either a file path, an object with file paths for dark and light"
-            "themes, or a theme icon references, like `$(zap)`"
-        ),
+        description="Icon used to represent this submenu in the UI, on"
+        " buttons or in menus. Can be a single string or two different options"
+        " for light and dark themes. These values may be:"
+        "<ul><li> a secure (https) URL </li>"
+        "<li>a string in the format `{package}:{resource}`, where `package` and "
+        "`resource` are arguments to `importlib.resources.files(package, resource)` "
+        "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+        "shipped with the sdist)"
+        "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
+        "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
+        "any fonticon libraries they use, e.g "
+        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
     )

--- a/src/npe2/manifest/contributions/_submenu.py
+++ b/src/npe2/manifest/contributions/_submenu.py
@@ -26,7 +26,7 @@ class SubmenuContribution(BaseModel):
         " for light and dark themes. These values may be:"
         "<ul><li> a secure (https) URL </li>"
         "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.files(package, resource)` "
+        "`resource` are arguments to `importlib.resources.path(package, resource)` "
         "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
         "shipped with the sdist)"
         "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "

--- a/src/npe2/manifest/contributions/_submenu.py
+++ b/src/npe2/manifest/contributions/_submenu.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel, Field
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel, Field
+
+from npe2.manifest import _validators
 
 from ._icon import Icon
 
@@ -15,7 +19,7 @@ class SubmenuContribution(BaseModel):
     label: str = Field(
         description="The label of the menu item which leads to this submenu."
     )
-    icon: str | Icon | None = Field(
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.coerce_icon)] = Field(
         None,
         description="Icon used to represent this submenu in the UI, on"
         " buttons or in menus. Can be a single string or two different options"

--- a/src/npe2/manifest/contributions/_submenu.py
+++ b/src/npe2/manifest/contributions/_submenu.py
@@ -22,16 +22,16 @@ class SubmenuContribution(BaseModel):
     icon: Annotated[str | Icon | None, AfterValidator(_validators.validate_icon)] = (
         Field(
             None,
-            description="Icon used to represent this submenu in the UI, on"
-            " buttons or in menus. Can be a single string or two different options"
-            " for light and dark themes. These values may be:"
-            "<li>a string in the format `{package}:{resource}`, where `package` and "
+            description="Icon used to represent this command in the UI, on "
+            "buttons or in menus. Can be a single string or two different options "
+            "for light and dark themes. These values may be:"
+            "<ul><li>a string in format `{package}:{resource}`, where `package` and"
             "`resource` are arguments to `importlib.resources.path(package, resource)` "
-            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
-            "shipped with the sdist)"
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be shipped"
+            "with the wheel, e.g. via the `package-data` entry in pyproject.toml)"
             "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
             "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
-            "any fonticon libraries they use, e.g "
-            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+            "any fonticon libraries they use, e.g. "
+            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))",
         )
     )

--- a/src/npe2/manifest/contributions/_submenu.py
+++ b/src/npe2/manifest/contributions/_submenu.py
@@ -19,18 +19,19 @@ class SubmenuContribution(BaseModel):
     label: str = Field(
         description="The label of the menu item which leads to this submenu."
     )
-    icon: Annotated[str | Icon | None, AfterValidator(_validators.coerce_icon)] = Field(
-        None,
-        description="Icon used to represent this submenu in the UI, on"
-        " buttons or in menus. Can be a single string or two different options"
-        " for light and dark themes. These values may be:"
-        "<ul><li> a secure (https) URL </li>"
-        "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.path(package, resource)` "
-        "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
-        "shipped with the sdist)"
-        "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
-        "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
-        "any fonticon libraries they use, e.g "
-        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.validate_icon)] = (
+        Field(
+            None,
+            description="Icon used to represent this submenu in the UI, on"
+            " buttons or in menus. Can be a single string or two different options"
+            " for light and dark themes. These values may be:"
+            "<li>a string in the format `{package}:{resource}`, where `package` and "
+            "`resource` are arguments to `importlib.resources.path(package, resource)` "
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+            "shipped with the sdist)"
+            "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
+            "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
+            "any fonticon libraries they use, e.g "
+            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+        )
     )

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -123,7 +123,7 @@ class PluginManifest(ImportExportModel):
         "results, change this to `'hidden'`.",
     )
 
-    icon: Annotated[str | Icon | None, AfterValidator(_validators.icon_path)] = Field(
+    icon: str | Icon | None = Field(
         None,
         description="Icon used to represent this plugin in the UI, on"
         " buttons or in menus. Can be a single string or two different options"
@@ -249,6 +249,26 @@ class PluginManifest(ImportExportModel):
     @field_validator("contributions", mode="before")
     def _coerce_none_contributions(cls, value):
         return ContributionPoints() if value is None else value
+
+    @field_validator("icon", mode="after")
+    def _coerce_icon(cls, value):
+        if isinstance(value, str) and value.startswith("http"):
+            if not value.startswith("https://"):
+                raise ValueError(
+                    f"{value} is not a valid icon URL. It must start with 'https://'"
+                )
+        if isinstance(value, Icon):
+            if value.light is not None and value.light.startswith("http"):
+                if not value.light.startswith("https://"):
+                    raise ValueError(
+                        f"{value.light} is not a valid icon URL. It must start with 'https://'"
+                    )
+            if value.dark is not None and value.dark.startswith("http"):
+                if not value.dark.startswith("https://"):
+                    raise ValueError(
+                        f"{value.dark} is not a valid icon URL. It must start with 'https://'"
+                    )
+        return value
 
     @model_validator(mode="before")
     @classmethod

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -123,7 +123,7 @@ class PluginManifest(ImportExportModel):
         "results, change this to `'hidden'`.",
     )
 
-    icon: str | Icon | None = Field(
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.coerce_icon)] = Field(
         None,
         description="Icon used to represent this plugin in the UI, on"
         " buttons or in menus. Can be a single string or two different options"
@@ -249,26 +249,6 @@ class PluginManifest(ImportExportModel):
     @field_validator("contributions", mode="before")
     def _coerce_none_contributions(cls, value):
         return ContributionPoints() if value is None else value
-
-    @field_validator("icon", mode="after")
-    def _coerce_icon(cls, value):
-        if isinstance(value, str) and value.startswith("http"):
-            if not value.startswith("https://"):
-                raise ValueError(
-                    f"{value} is not a valid icon URL. It must start with 'https://'"
-                )
-        if isinstance(value, Icon):
-            if value.light is not None and value.light.startswith("http"):
-                if not value.light.startswith("https://"):
-                    raise ValueError(
-                        f"{value.light} is not a valid icon URL. It must start with 'https://'"
-                    )
-            if value.dark is not None and value.dark.startswith("http"):
-                if not value.dark.startswith("https://"):
-                    raise ValueError(
-                        f"{value.dark} is not a valid icon URL. It must start with 'https://'"
-                    )
-        return value
 
     @model_validator(mode="before")
     @classmethod

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -130,7 +130,7 @@ class PluginManifest(ImportExportModel):
         " for light and dark themes. These values may be:"
         "<ul><li> a secure (https) URL </li>"
         "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.files(package, resource)` "
+        "`resource` are arguments to `importlib.resources.path(package, resource)` "
         "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
         "shipped with the sdist)"
         "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -27,6 +27,7 @@ from . import _validators
 from ._bases import ImportExportModel
 from ._package_metadata import PackageMetadata
 from .contributions import ContributionPoints
+from .contributions._icon import Icon
 from .utils import Executable, Version
 
 __all__ = ("Category",)
@@ -122,17 +123,21 @@ class PluginManifest(ImportExportModel):
         "results, change this to `'hidden'`.",
     )
 
-    icon: Annotated[str, AfterValidator(_validators.icon_path)] = Field(
-        "",
-        description="The path to a square PNG icon of at least 128x128 pixels (256x256 "
-        "for Retina screens). May be one of: "
-        "<ul><li>a secure (https) URL </li>"
-        "<li>a path relative to the manifest file, (must be shipped in the sdist)</li>"
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.icon_path)] = Field(
+        None,
+        description="Icon used to represent this plugin in the UI, on"
+        " buttons or in menus. Can be a single string or two different options"
+        " for light and dark themes. These values may be:"
+        "<ul><li> a secure (https) URL </li>"
         "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.path(package, resource)`, "
-        "(e.g. `top_module.some_folder:my_logo.png`).</li></ul>",
+        "`resource` are arguments to `importlib.resources.files(package, resource)` "
+        "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+        "shipped with the sdist)"
+        "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
+        "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
+        "any fonticon libraries they use, e.g "
+        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
     )
-
     categories: list[Category] = Field(
         default_factory=list,
         description="A list of categories that this plugin belongs to. This is used to "

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -123,20 +123,21 @@ class PluginManifest(ImportExportModel):
         "results, change this to `'hidden'`.",
     )
 
-    icon: Annotated[str | Icon | None, AfterValidator(_validators.coerce_icon)] = Field(
-        None,
-        description="Icon used to represent this plugin in the UI, on"
-        " buttons or in menus. Can be a single string or two different options"
-        " for light and dark themes. These values may be:"
-        "<ul><li> a secure (https) URL </li>"
-        "<li>a string in the format `{package}:{resource}`, where `package` and "
-        "`resource` are arguments to `importlib.resources.path(package, resource)` "
-        "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
-        "shipped with the sdist)"
-        "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
-        "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
-        "any fonticon libraries they use, e.g "
-        "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+    icon: Annotated[str | Icon | None, AfterValidator(_validators.validate_icon)] = (
+        Field(
+            None,
+            description="Icon used to represent this plugin in the UI, on"
+            " buttons or in menus. Can be a single string or two different options"
+            " for light and dark themes. These values may be:"
+            "<li>a string in the format `{package}:{resource}`, where `package` and "
+            "`resource` are arguments to `importlib.resources.path(package, resource)` "
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
+            "shipped with the sdist)"
+            "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
+            "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
+            "any fonticon libraries they use, e.g "
+            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+        )
     )
     categories: list[Category] = Field(
         default_factory=list,

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -126,17 +126,17 @@ class PluginManifest(ImportExportModel):
     icon: Annotated[str | Icon | None, AfterValidator(_validators.validate_icon)] = (
         Field(
             None,
-            description="Icon used to represent this plugin in the UI, on"
-            " buttons or in menus. Can be a single string or two different options"
-            " for light and dark themes. These values may be:"
-            "<li>a string in the format `{package}:{resource}`, where `package` and "
+            description="Icon used to represent this command in the UI, on "
+            "buttons or in menus. Can be a single string or two different options "
+            "for light and dark themes. These values may be:"
+            "<ul><li>a string in format `{package}:{resource}`, where `package` and"
             "`resource` are arguments to `importlib.resources.path(package, resource)` "
-            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
-            "shipped with the sdist)"
+            "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be shipped"
+            "with the wheel, e.g. via the `package-data` entry in pyproject.toml)"
             "<li> a [superqt](https://github.com/napari/superqt) fonticon key, such as "
             "`'fa6s.arrow_down'` (though note that plugins are expected to depend on "
-            "any fonticon libraries they use, e.g "
-            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))</li></ul>",
+            "any fonticon libraries they use, e.g. "
+            "[fonticon-fontawesome6](https://github.com/tlambert03/fonticon-fontawesome6))",
         )
     )
     categories: list[Category] = Field(

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -2,7 +2,7 @@ name: my-plugin
 display_name: My Plugin
 on_activate: my_plugin:activate
 on_deactivate: my_plugin:deactivate
-icon: https://picsum.photos/256
+icon: my_plugin:myicon.png
 contributions:
   commands:
     - id: my-plugin.hello_world

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -182,7 +182,18 @@ def test_visibility():
 
 
 def test_icon():
-    PluginManifest(name="myplugin", icon="my_plugin:myicon.png")
+    pm = PluginManifest(name="myplugin", icon="my_plugin:myicon.png")
+    assert pm.icon == "my_plugin:myicon.png"
+    pm = PluginManifest(name="myplugin", icon="https://example.com/icon.png")
+    assert pm.icon == "https://example.com/icon.png"
+    with pytest.raises(ValueError, match="not a valid icon URL"):
+        pm = PluginManifest(name="myplugin", icon="http://example.com/bad_icon.png")
+    pm = PluginManifest(
+        name="myplugin",
+        icon={"dark": "my_plugin:myicon.png", "light": "https://example.com/icon.png"},
+    )
+    assert pm.icon.dark == "my_plugin:myicon.png"
+    assert pm.icon.light == "https://example.com/icon.png"
 
 
 def test_dotted_plugin_name():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from npe2 import PluginManifest
 from npe2.manifest import PackageMetadata
+from npe2.manifest.contributions._icon import Icon
 from npe2.manifest.schema import ENTRY_POINT
 
 SAMPLE_PLUGIN_NAME = "my-plugin"
@@ -192,6 +193,7 @@ def test_icon():
         name="myplugin",
         icon={"dark": "my_plugin:myicon.png", "light": "https://example.com/icon.png"},
     )
+    assert isinstance(pm.icon, Icon)
     assert pm.icon.dark == "my_plugin:myicon.png"
     assert pm.icon.light == "https://example.com/icon.png"
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -185,17 +185,16 @@ def test_visibility():
 def test_icon():
     pm = PluginManifest(name="myplugin", icon="my_plugin:myicon.png")
     assert pm.icon == "my_plugin:myicon.png"
-    pm = PluginManifest(name="myplugin", icon="https://example.com/icon.png")
-    assert pm.icon == "https://example.com/icon.png"
-    with pytest.raises(ValueError, match="not a valid icon URL"):
-        pm = PluginManifest(name="myplugin", icon="http://example.com/bad_icon.png")
     pm = PluginManifest(
         name="myplugin",
-        icon={"dark": "my_plugin:myicon.png", "light": "https://example.com/icon.png"},
+        icon={
+            "dark": "my_plugin:myicon_dark.png",
+            "light": "my_plugin:myicon_light.png",
+        },
     )
     assert isinstance(pm.icon, Icon)
-    assert pm.icon.dark == "my_plugin:myicon.png"
-    assert pm.icon.light == "https://example.com/icon.png"
+    assert pm.icon.dark == "my_plugin:myicon_dark.png"
+    assert pm.icon.light == "my_plugin:myicon_light.png"
 
 
 def test_dotted_plugin_name():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,6 +7,10 @@ from pydantic import ValidationError
 
 from npe2 import PluginManifest
 from npe2.manifest import PackageMetadata
+from npe2.manifest.contributions import (
+    CommandContribution,
+    SubmenuContribution
+)
 from npe2.manifest.contributions._icon import Icon
 from npe2.manifest.schema import ENTRY_POINT
 
@@ -185,6 +189,10 @@ def test_visibility():
 def test_icon():
     pm = PluginManifest(name="myplugin", icon="my_plugin:myicon.png")
     assert pm.icon == "my_plugin:myicon.png"
+
+    pm = PluginManifest(name="myplugin", icon="my_plugin.module.submodule:myicon.png")
+    assert pm.icon == "my_plugin.module.submodule:myicon.png"
+
     # different icons per theme should be settable
     pm = PluginManifest(
         name="myplugin",
@@ -200,6 +208,20 @@ def test_icon():
     # fonticon and iconify should work
     pm = PluginManifest(name="myplugin", icon="fa6s.arrow_down")
     pm = PluginManifest(name="myplugin", icon="fa6-solid:circle")
+
+    command = CommandContribution(
+        id="myplugin.command",
+        title="Run command",
+        icon="fa6s.arrow_down",
+    )
+    assert command.icon == "fa6s.arrow_down"
+
+    submenu = SubmenuContribution(
+        id="myplugin.submenu",
+        label="Tools",
+        icon="fa6-solid:circle",
+    )
+    assert submenu.icon == "fa6-solid:circle"
 
 
 def test_dotted_plugin_name():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,10 +7,7 @@ from pydantic import ValidationError
 
 from npe2 import PluginManifest
 from npe2.manifest import PackageMetadata
-from npe2.manifest.contributions import (
-    CommandContribution,
-    SubmenuContribution
-)
+from npe2.manifest.contributions import CommandContribution, SubmenuContribution
 from npe2.manifest.contributions._icon import Icon
 from npe2.manifest.schema import ENTRY_POINT
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -185,6 +185,7 @@ def test_visibility():
 def test_icon():
     pm = PluginManifest(name="myplugin", icon="my_plugin:myicon.png")
     assert pm.icon == "my_plugin:myicon.png"
+    # different icons per theme should be settable
     pm = PluginManifest(
         name="myplugin",
         icon={
@@ -195,6 +196,10 @@ def test_icon():
     assert isinstance(pm.icon, Icon)
     assert pm.icon.dark == "my_plugin:myicon_dark.png"
     assert pm.icon.light == "my_plugin:myicon_light.png"
+
+    # fonticon and iconify should work
+    pm = PluginManifest(name="myplugin", icon="fa6s.arrow_down")
+    pm = PluginManifest(name="myplugin", icon="fa6-solid:circle")
 
 
 def test_dotted_plugin_name():

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -68,9 +68,19 @@ def _mutator_writer_invalid_file_extension_2(data):
     data["contributions"]["writers"][0]["filename_extensions"] = ["."]
 
 
-def _mutator_invalid_icon(data):
-    """is not a valid path"""
+def _mutator_invalid_icon_1(data):
+    """is not a valid"""
     data["icon"] = "my_plugin/icon.png"
+
+
+def _mutator_invalid_icon_2(data):
+    """is not a valid"""
+    data["icon"] = "too:many:colons"
+
+
+def _mutator_invalid_icon_3(data):
+    """is not a valid"""
+    data["icon"] = "too.many.dots.and.no.colons"
 
 
 @pytest.mark.parametrize(
@@ -86,7 +96,9 @@ def _mutator_invalid_icon(data):
         _mutator_writer_invalid_layer_type_constraint,
         _mutator_writer_invalid_file_extension_1,
         _mutator_writer_invalid_file_extension_2,
-        _mutator_invalid_icon,
+        _mutator_invalid_icon_1,
+        _mutator_invalid_icon_2,
+        _mutator_invalid_icon_3,
     ],
 )
 def test_invalid(mutator, uses_sample_plugin):

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -69,8 +69,8 @@ def _mutator_writer_invalid_file_extension_2(data):
 
 
 def _mutator_invalid_icon(data):
-    """is not a valid icon URL. It must start with 'https://'"""
-    data["icon"] = "http://example.com/icon.png"
+    """is not a valid path"""
+    data["icon"] = "my_plugin/icon.png"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR aims to unify a bit the manifest regarding icons, and to bring it more in line with what the underlying app-model accepts.

We actually "officially" support more things than appmodel (e.g: https urls), and I'm not sure whether we plan to keep these and handle the extra logic ourselves or what else to do. At least with this we start supporting dark/light for all icon fields.
