### PR TITLE
Fix model schema generation

### DIFF
--- a/_docs/render.py
+++ b/_docs/render.py
@@ -186,7 +186,7 @@ def main(dest: Path = _BUILD):
             schema = json.load(f)
     else:
         try:
-            schema = PluginManifest.model_json_shema()
+            schema = PluginManifest.model_json_schema()
         except Exception:
             with urlopen(SCHEMA_URL) as response:
                 schema = json.load(response)


### PR DESCRIPTION
I noticed this typo over in a failed doc build in `napari`. I guess it was never noticed because it's under a `try: .. except Exception` block.