### PR TITLE
Remove render.py from mypy pre-commit exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,4 @@ repos:
       additional_dependencies:
         - types-toml
         - types-PyYAML
-      exclude: npe2/implements.pyi|_docs/render.py
+      exclude: npe2/implements.pyi

--- a/_docs/render.py
+++ b/_docs/render.py
@@ -186,7 +186,7 @@ def main(dest: Path = _BUILD):
             schema = json.load(f)
     else:
         try:
-            schema = PluginManifest.model_json_shema()
+            schema = PluginManifest.model_json_schema()
         except Exception:
             with urlopen(SCHEMA_URL) as response:
                 schema = json.load(response)


### PR DESCRIPTION
After landing #451, remove `render.py` as an exclusion from pre-commit config.