### PR TITLE
Remove stale fetch test that has been skipped for over 2 years

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -21,16 +21,6 @@ def test_fetch_npe2_manifest():
     assert mf.npe1_shim is False
 
 
-@pytest.mark.skip("package looks deleted from pypi")
-def test_fetch_npe1_manifest_with_writer():
-    mf = fetch_manifest("dummy-test-plugin", version="0.1.3")
-    assert mf.name == "example-plugin"
-    assert mf.contributions.writers
-    # Test will eventually fail when example-plugin is updated to npe2
-    # This is here as a sentinel
-    assert mf.npe1_shim is True
-
-
 def test_fetch_npe1_manifest_with_sample_data():
     mf = fetch_manifest("napari-kics")
     assert mf.name == "napari-kics"


### PR DESCRIPTION
This PR removes a stale test that uses `napari/dummy-test-plugin`. The test is currently being skipped and has been skipped for almost 3 years.

`napari/dummy-test-plugin` was archived.

We have 2 options to fix this skipped test:
1. Remove the test
2. Find a new example to test instead of `napari/dummy-test-plugin`

This PR uses Option 1 and removes the test.