### PR TITLE
Defer importing jsonschema.exceptions

### DIFF
--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -6,7 +6,6 @@ from ._json_schema import (
     Draft07JsonSchema,
     JsonType,
     JsonTypeArray,
-    ValidationError,
     _coerce_type_name,
 )
 
@@ -116,9 +115,11 @@ class ConfigurationProperty(Draft07JsonSchema):
 
     def validate_instance(self, instance: object) -> dict:
         """Validate an object (instance) against this schema."""
+        from ._json_schema import ValidationError as JsonSchemaValidationError
+
         try:
             return super().validate_instance(instance)
-        except ValidationError as e:
+        except JsonSchemaValidationError as e:
             if e.validator == "pattern" and self.pattern_error_message:
                 e.message = self.pattern_error_message
             raise e

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -18,11 +18,18 @@ from pydantic import (
 if TYPE_CHECKING:
     from jsonschema.exceptions import ValidationError
     from jsonschema.protocols import Validator
-else:
-    try:
-        from jsonschema.exceptions import ValidationError
-    except ImportError:
-        ValidationError = Exception
+
+
+# use PEP562 to defer the import of jsonschema.exceptions
+def __getattr__(name: str) -> Any:
+    if name == "ValidationError":
+        try:
+            from jsonschema.exceptions import ValidationError as validation_error
+        except ImportError:
+            validation_error = Exception
+        return validation_error
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "Draft04JsonSchema",


### PR DESCRIPTION
Part of: https://github.com/napari/napari/issues/8689

The eager loading of this module costs ~20 ms in napari import time.
This uses PEP 562 to defer the import until it's called. Given that it's behind a try/except anyways, it seems harmless to defer this.