### PR TITLE
Accept `pathlib.Path` in reading and writing utilities

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -115,10 +115,15 @@ class _ContributionsIndex:
     def get_command(self, command_id: str) -> CommandContribution:
         return self._commands[command_id][0]
 
-    def iter_compatible_readers(self, paths: list[str]) -> Iterator[ReaderContribution]:
+    def iter_compatible_readers(
+        self, paths: list[PathLike]
+    ) -> Iterator[ReaderContribution]:
         assert isinstance(paths, list)
         if not paths:
             return  # pragma: no cover
+
+        # normalise Path -> str (urlparse/fnmatch and reader plugins expect str)
+        paths = [os.fspath(p) for p in paths]
 
         if len({Path(i).suffix for i in paths}) > 1:
             raise ValueError(
@@ -621,13 +626,13 @@ class PluginManager:
             yield from mf.contributions.themes or ()
 
     def iter_compatible_readers(
-        self, path: PathLike | Sequence[str]
+        self, path: PathLike | Sequence[PathLike]
     ) -> Iterator[ReaderContribution]:
         """Iterate over ReaderContributions compatible with `path`.
 
         Parameters
         ----------
-        path : PathLike | Sequence[str]
+        path : PathLike | Sequence[PathLike]
             Pathlike or list of pathlikes, with file(s) to read.
         """
         if isinstance(path, (str, Path)):
@@ -661,7 +666,10 @@ class PluginManager:
                 yield mf.name, mf.contributions.sample_data
 
     def get_writer(
-        self, path: str, layer_types: Sequence[str], plugin_name: str | None = None
+        self,
+        path: PathLike,
+        layer_types: Sequence[str],
+        plugin_name: str | None = None,
     ) -> tuple[WriterContribution | None, str]:
         """Get Writer contribution appropriate for `path`, and `layer_types`.
 
@@ -673,7 +681,7 @@ class PluginManager:
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Path to write
         layer_types : Sequence[str]
             Sequence of layer type strings (e.g. ['image', 'labels'])
@@ -686,6 +694,8 @@ class PluginManager:
         Tuple[Optional[WriterContribution], str]
             WriterContribution and path that will be written.
         """
+        # normalise Path -> str for suffix matching and `path + ext` below
+        path = os.fspath(path) if path else ""
         ext = Path(path).suffix.lower() if path else ""
 
         for writer in self.iter_compatible_writers(layer_types):

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
@@ -11,7 +12,7 @@ from typing import (
 
 from . import PluginManager
 from .manifest.utils import v1_to_v2
-from .types import FullLayerData, LayerData
+from .types import FullLayerData, LayerData, PathLike
 
 if TYPE_CHECKING:
     import napari.layers
@@ -19,14 +20,27 @@ if TYPE_CHECKING:
     from .manifest.contributions import ReaderContribution, WriterContribution
 
 
+def _normalize_paths(paths: PathLike | Sequence[PathLike]) -> str | list[str]:
+    """Normalise ``PathLike`` input to ``str`` for downstream/plugin use.
+
+    npe2 accepts ``str`` or ``pathlib.Path`` at its public API, but reader and
+    writer plugins (and the internal matching logic) expect ``str``. ``Path``
+    objects are converted with ``os.fspath``; ``str`` (including remote URLs)
+    is returned unchanged.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        return os.fspath(paths)
+    return [os.fspath(p) for p in paths]
+
+
 def read(
-    paths: list[str], *, stack: bool, plugin_name: str | None = None
+    paths: Sequence[PathLike], *, stack: bool, plugin_name: str | None = None
 ) -> list[LayerData]:
     """Try to read file at `path`, with plugins offering a ReaderContribution.
 
     Parameters
     ----------
-    paths : list of str
+    paths : list of str or pathlib.Path
         Path to the file or resource being read.
     stack : bool
         Should the readers stack the read files.
@@ -50,12 +64,14 @@ def read(
 
 
 def read_get_reader(
-    path: str | Sequence[str],
+    path: PathLike | Sequence[PathLike],
     *,
     plugin_name: str | None = None,
     stack: bool | None = None,
 ) -> tuple[list[LayerData], ReaderContribution]:
     """Variant of `read` that also returns the `ReaderContribution` used."""
+    # normalise Path -> str before the assertions / dispatch below
+    path = _normalize_paths(path)
     if stack is None:
         # "npe1" old path
         # Napari 0.4.15 and older, hopefully we can drop this and make stack mandatory
@@ -71,7 +87,7 @@ def read_get_reader(
 
 
 def write(
-    path: str,
+    path: PathLike,
     layer_data: list[FullLayerData | napari.layers.Layer],
     *,
     plugin_name: str | None = None,
@@ -80,7 +96,7 @@ def write(
 
     Parameters
     ----------
-    path : str
+    path : str or pathlib.Path
         The path (file, directory, url) to write.
     layer_data : list of layer data tuples
         List of tuples in the form (data, metadata_dict, layer_type_string)
@@ -103,7 +119,7 @@ def write(
 
 
 def write_get_writer(
-    path: str,
+    path: PathLike,
     layer_data: list[FullLayerData | napari.layers.Layer],
     *,
     plugin_name: str | None = None,
@@ -117,7 +133,7 @@ def write_get_writer(
 
 @overload
 def _read(
-    paths: str | Sequence[str],
+    paths: PathLike | Sequence[PathLike],
     *,
     stack: bool,
     plugin_name: str | None = None,
@@ -128,7 +144,7 @@ def _read(
 
 @overload
 def _read(
-    paths: str | Sequence[str],
+    paths: PathLike | Sequence[PathLike],
     *,
     stack: bool,
     plugin_name: str | None = None,
@@ -138,7 +154,7 @@ def _read(
 
 
 def _read(
-    paths: str | Sequence[str],
+    paths: PathLike | Sequence[PathLike],
     *,
     stack: bool,
     plugin_name: str | None = None,
@@ -148,6 +164,9 @@ def _read(
     """Execute the `read...` functions above."""
     if _pm is None:
         _pm = PluginManager.instance()
+
+    # normalise Path -> str so reader plugins receive str
+    paths = _normalize_paths(paths)
 
     # get readers compatible with paths and chosen plugin - raise errors if
     # choices are invalid or there's nothing to try
@@ -189,7 +208,9 @@ def _read(
 
 
 def _get_compatible_readers_by_choice(
-    plugin_name: str | None, paths: str | Sequence[str], pm: PluginManager
+    plugin_name: str | None,
+    paths: PathLike | Sequence[PathLike],
+    pm: PluginManager,
 ):
     """Returns compatible readers filtered by validated plugin choice.
 
@@ -295,7 +316,7 @@ def _is_null_layer_sentinel(layer_data: Any) -> bool:
 
 @overload
 def _write(
-    path: str,
+    path: PathLike,
     layer_data: list[FullLayerData | napari.layers.Layer],
     *,
     plugin_name: str | None = None,
@@ -306,7 +327,7 @@ def _write(
 
 @overload
 def _write(
-    path: str,
+    path: PathLike,
     layer_data: list[FullLayerData | napari.layers.Layer],
     *,
     plugin_name: str | None = None,
@@ -316,7 +337,7 @@ def _write(
 
 
 def _write(
-    path: str,
+    path: PathLike,
     layer_data: list[FullLayerData | napari.layers.Layer],
     *,
     plugin_name: str | None = None,
@@ -327,6 +348,9 @@ def _write(
         raise ValueError("Must provide layer data")
     if _pm is None:
         _pm = PluginManager.instance()
+
+    # normalise Path -> str so writer plugins receive str
+    path = os.fspath(path)
 
     _layer_tuples: list[FullLayerData] = [
         (

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -59,7 +59,6 @@ def read(
     ValueError
         If no readers are found or none return data
     """
-    assert isinstance(paths, list)
     return _read(paths, plugin_name=plugin_name, stack=stack)
 
 

--- a/src/npe2/types.py
+++ b/src/npe2/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 from collections.abc import Callable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
@@ -17,8 +18,9 @@ if TYPE_CHECKING:
 
 # General types
 
-# PathLike = Union[str, pathlib.Path]  # we really have to pick one
-PathLike = str
+# Accept str or pathlib.Path at the public API; paths are normalised to str
+# internally before plugin dispatch (see io_utils / _plugin_manager).
+PathLike = str | pathlib.Path
 PathOrPaths = PathLike | Sequence[PathLike]
 PythonName = NewType("PythonName", str)
 

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -85,6 +85,34 @@ def test_read_uses_correct_passed_plugin(tmp_path):
         io_utils._read(["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm)
 
 
+def test_pathlib_normalized_to_str_for_plugins():
+    """Plugins must keep receiving ``str`` even when callers pass ``Path``.
+
+    Existing reader plugins assume ``str`` (e.g. ``path.startswith(...)``), so
+    npe2 normalises ``pathlib.Path`` to ``str`` before dispatching.
+    """
+    pm = PluginManager()
+    plugin = DynamicPlugin("str-only", plugin_manager=pm)
+    plugin.register()
+
+    received: dict = {}
+
+    @plugin.contribute.reader(filename_patterns=["*.fzzy"])
+    def get_read(path):
+        received["getter"] = path
+
+        def reader_func(paths):
+            received["reader"] = paths
+            return [(None,)]
+
+        return reader_func
+
+    io_utils._read([Path("some.fzzy")], stack=False, _pm=pm)
+    assert isinstance(received["getter"], str)
+    # the reader function receives the (normalised) list of str paths
+    assert all(isinstance(p, str) for p in received["reader"])
+
+
 def test_read_fails_with_refused_reader():
     pm = PluginManager()
     plugin_name = "always-fails"
@@ -225,6 +253,25 @@ def test_read_list(uses_sample_plugin):
     assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
 
 
+def test_read_pathlib(uses_sample_plugin):
+    """pathlib.Path inputs are accepted, not only str."""
+    assert read([Path("some.fzzy")], stack=False) == [(None,)]
+
+
+def test_read_return_reader_pathlib(uses_sample_plugin):
+    """pathlib.Path inputs are accepted by read_get_reader (npe1 path)."""
+    data, reader = read_get_reader(Path("some.fzzy"))
+    assert data == [(None,)]
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+
+def test_read_list_pathlib(uses_sample_plugin):
+    """A stacked list of pathlib.Path inputs is accepted."""
+    data, reader = read_get_reader([Path("some.fzzy"), Path("other.fzzy")])
+    assert data == [(None,)]
+    assert reader.command == f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+
 null_image: FullLayerData = ([], {}, "image")
 
 
@@ -234,6 +281,17 @@ def test_writer_exec(uses_sample_plugin):
     assert result == ["test.tif"]
 
     result, contrib = write_get_writer("test.tif", [null_image, null_image])
+    assert result == ["test.tif"]
+    assert contrib.command == f"{SAMPLE_PLUGIN_NAME}.my_writer"
+
+
+def test_writer_exec_pathlib(uses_sample_plugin):
+    """pathlib.Path inputs are accepted by the write helpers, returning str."""
+    result = write(Path("test.tif"), [null_image, null_image])
+    assert result == ["test.tif"]
+    assert all(isinstance(p, str) for p in result)
+
+    result, contrib = write_get_writer(Path("test.tif"), [null_image, null_image])
     assert result == ["test.tif"]
     assert contrib.command == f"{SAMPLE_PLUGIN_NAME}.my_writer"
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -196,6 +196,26 @@ def test_warn_on_register_disabled(uses_sample_plugin, plugin_manager: PluginMan
         plugin_manager.register(mf)
 
 
+def test_iter_compatible_readers_pathlib(
+    uses_sample_plugin, plugin_manager: PluginManager
+):
+    """`iter_compatible_readers` accepts a single Path and a list of Paths."""
+    from pathlib import Path
+
+    expected = f"{SAMPLE_PLUGIN_NAME}.some_reader"
+
+    cmds = [r.command for r in plugin_manager.iter_compatible_readers(Path("a.fzzy"))]
+    assert expected in cmds
+
+    cmds = [
+        r.command
+        for r in plugin_manager.iter_compatible_readers(
+            [Path("a.fzzy"), Path("b.fzzy")]
+        )
+    ]
+    assert expected in cmds
+
+
 def test_plugin_manager_dict(uses_sample_plugin, plugin_manager: PluginManager):
     """Test exporting the plugin manager state with `dict()`."""
     d = plugin_manager.dict()


### PR DESCRIPTION
The reading and writing utilities accepted only `str` paths. This widens them to also accept `pathlib.Path`, in addition to `str`, so callers (napari included) no longer have to stringify paths before calling npe2.

The approach is to accept `PathLike` (`str | pathlib.Path`) at the public API and normalise `Path` to `str` with `os.fspath` before any path matching or plugin dispatch. Reader and writer plugins keep receiving `str`, so existing plugins are unaffected. Remote URLs are passed as `str` and pass through unchanged.

Changes:

- `types.PathLike` is now `str | pathlib.Path` (was `str`).
- `io_utils`: `read`, `read_get_reader`, `write`, `write_get_writer` (and the internal `_read` / `_write` / `_get_compatible_readers_by_choice`) accept and normalise `Path`.
- `PluginManager`: `iter_compatible_readers` and `get_writer` accept and normalise `Path`.

Resolves the npe2 side of napari/napari#8586.

## Testing strategy

- Added `Path` based tests in `tests/test__io_utils.py` covering `read`, `read_get_reader` (single and stacked), `write`, and `write_get_writer`.
- Added a test asserting that reader plugins still receive `str` when a `Path` is passed, to lock in backwards compatibility.
- Added a `Path` test for `PluginManager.iter_compatible_readers` in `tests/test_plugin_manager.py`.
- Existing `str` based tests are unchanged and still pass, confirming no behaviour change for current callers.

Run:

```
uv run --extra testing pytest -q
```
<img width="1152" height="627" alt="Screenshot 2026-06-09 at 3 07 36 PM" src="https://github.com/user-attachments/assets/036c9fa0-9149-41b9-83c1-c25e11adb746" />
