### PR TITLE
Log Warning for null layer sentinel instead of ValueError

### DIFF
--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import warnings
+import logging
 from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from .manifest.contributions import ReaderContribution, WriterContribution
 
+logger = logging.getLogger(__name__)
 
 def read(
     paths: list[str], *, stack: bool, plugin_name: str | None = None
@@ -181,14 +182,11 @@ def _read(
         # used e.g. by napari's built-in .py reader (scripts modify the
         # viewer directly) and by third-party plugins that handle files
         # through non-layer pathways, like opening a widget.
-        # We warn informatively when the user explicitly chose this plugin,
-        # but still return the data so the caller can handle it.
         if plugin_name and _is_null_layer_sentinel(layer_data):
-            warnings.warn(
+            logger.warning(
                 f"Reader {plugin_name!r} was selected to open {paths!r}, "
-                "but opened no layers`. This may be intentional. If you "
-                "expected layers to be opened, contact the plugin author",
-                stacklevel=2,
+                "and opened no layers. This may be intentional. If you "
+                "expected layers to be opened, contact the plugin author."
             )
 
         # ── reader returns truthy ────────────────────

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 def read(
     paths: list[str], *, stack: bool, plugin_name: str | None = None
 ) -> list[LayerData]:

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
@@ -163,16 +164,21 @@ def _read(
         read_func = rdr.exec(
             kwargs={"path": paths, "stack": stack, "_registry": _pm.commands}
         )
-        if read_func is not None:
-            tried_reader = True
-            # if the reader function raises an exception here, we don't try to catch it
-            layer_data = read_func(paths, stack=stack)
-            if plugin_name and _is_null_layer_sentinel(layer_data):
-                # we don't return null layers if the user selected a plugin,
-                # so that we can raise a meaningful error
-                continue
-            if layer_data:
-                return (layer_data, rdr) if return_reader else layer_data
+        if read_func is None:
+            continue
+
+        tried_reader = True
+        layer_data = read_func(paths, stack=stack)
+        if plugin_name and _is_null_layer_sentinel(layer_data):
+            warnings.warn(
+                f"Reader {plugin_name!r} was selected to open {paths!r}, "
+                "but returned the null layer sentinel `[(None,)]`. This "
+                "may be intentional — e.g. the reader may have executed "
+                "a script or opened a widget instead of producing layers",
+                stacklevel=2,
+            )
+        if layer_data:
+            return (layer_data, rdr) if return_reader else layer_data
 
     if plugin_name:
         if tried_reader:

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -164,11 +164,25 @@ def _read(
         read_func = rdr.exec(
             kwargs={"path": paths, "stack": stack, "_registry": _pm.commands}
         )
+        # ── Path A: reader refused the file ──────────────────────────────
+        # rdr.exec() returned None -> the reader is skipped; tried_reader stays False.
         if read_func is None:
             continue
 
+        # ── Path B: reader returned a callable -> actually read ───────────
         tried_reader = True
+        # if the reader function raises an exception here, we don't catch
+        # instead, it propagates to the caller.
         layer_data = read_func(paths, stack=stack)
+
+        # ── null layer sentinel [(None,)] ─────────────────────
+        # The reader accepted the file and processed it successfully, but
+        # has no layer data to return. This is a documented contract value
+        # used e.g. by napari's built-in .py reader (scripts modify the
+        # viewer directly) and by third-party plugins that handle files
+        # through non-layer pathways, like opening a widget.
+        # We warn informatively when the user explicitly chose this plugin,
+        # but still return the data so the caller can handle it.
         if plugin_name and _is_null_layer_sentinel(layer_data):
             warnings.warn(
                 f"Reader {plugin_name!r} was selected to open {paths!r}, "
@@ -177,20 +191,31 @@ def _read(
                 "a script or opened a widget instead of producing layers",
                 stacklevel=2,
             )
+
+        # ── reader returns truthy ────────────────────
+        # layer_data is truthy (non-empty list). Return immediately (success).
+        # Covers both null layer sentinel [(None,)]
+        # and genuine [(data, meta, layer_type)] tuples.
         if layer_data:
             return (layer_data, rdr) if return_reader else layer_data
 
+    # ── No reader succeeded ──────────────────────────────────────────────
     if plugin_name:
         if tried_reader:
+            # Path B was reached (reader accepted the file) but the reader
+            # function returned falsy data (e.g. []) or raised and was caught.
             raise ValueError(
                 f"Reader {plugin_name!r} was selected to open "
                 + f"{paths!r}, but returned no data."
             )
         else:
+            # Path A for all readers — none of them accepted the file.
             raise ValueError(
                 f"Reader {plugin_name!r} was selected to open "
                 + f"{paths!r}, but refused the file."
             )
+    # No plugin was specified and no reader returned data (all Path B
+    # returns were skipped because layer_data was falsy).
     raise ValueError(f"No readers returned data for {paths!r}")
 
 

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -184,7 +184,7 @@ def _read(
         # viewer directly) and by third-party plugins that handle files
         # through non-layer pathways, like opening a widget.
         if plugin_name and _is_null_layer_sentinel(layer_data):
-            logger.warning(
+            logger.debug(
                 f"Reader {plugin_name!r} was selected to open {paths!r}, "
                 "and opened no layers. This may be intentional. If you "
                 "expected layers to be opened, contact the plugin author."

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -186,9 +186,8 @@ def _read(
         if plugin_name and _is_null_layer_sentinel(layer_data):
             warnings.warn(
                 f"Reader {plugin_name!r} was selected to open {paths!r}, "
-                "but opened no layers`. This "
-                "may be intentional — e.g. the reader may have executed "
-                "a script or opened a widget instead of producing layers",
+                "but opened no layers`. This may be intentional. If you "
+                "expected layers to be opened, contact the plugin author"
                 stacklevel=2,
             )
 

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -187,7 +187,7 @@ def _read(
             warnings.warn(
                 f"Reader {plugin_name!r} was selected to open {paths!r}, "
                 "but opened no layers`. This may be intentional. If you "
-                "expected layers to be opened, contact the plugin author"
+                "expected layers to be opened, contact the plugin author",
                 stacklevel=2,
             )
 

--- a/src/npe2/io_utils.py
+++ b/src/npe2/io_utils.py
@@ -186,7 +186,7 @@ def _read(
         if plugin_name and _is_null_layer_sentinel(layer_data):
             warnings.warn(
                 f"Reader {plugin_name!r} was selected to open {paths!r}, "
-                "but returned the null layer sentinel `[(None,)]`. This "
+                "but opened no layers`. This "
                 "may be intentional — e.g. the reader may have executed "
                 "a script or opened a widget instead of producing layers",
                 stacklevel=2,

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -80,7 +80,7 @@ def test_read_uses_correct_passed_plugin(tmp_path, caplog):
 
     # "gooby-again" isn't used even though given plugin starts with the same name
     # the reader from "gooby" returns [(None,)] which is successfully returned
-    caplog.set_level(logging.WARNING, logger="npe2.io_utils")
+    caplog.set_level(logging.DEBUG, logger="npe2.io_utils")
     result = io_utils._read(["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm)
     assert result == [(None,)]
     assert any(
@@ -110,7 +110,7 @@ def test_read_fails_with_refused_reader():
 def test_read_succeeds_with_null_layer_and_chosen_plugin(caplog):
     """A selected reader returning [(None,)] is valid — it signals
     'file processed successfully, nothing to add to the viewer'.
-    A WARNING log message is issued when a plugin was explicitly chosen."""
+    A DEBUG log message is issued when a plugin was explicitly chosen."""
     pm = PluginManager()
     plugin_name = "always-fails"
     plugin = DynamicPlugin(plugin_name, plugin_manager=pm)
@@ -123,7 +123,7 @@ def test_read_succeeds_with_null_layer_and_chosen_plugin(caplog):
     def get_read(path):
         return reader_func
 
-    caplog.set_level(logging.WARNING, logger="npe2.io_utils")
+    caplog.set_level(logging.DEBUG, logger="npe2.io_utils")
     result = io_utils._read(["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm)
     assert result == [(None,)]
     assert any(
@@ -171,7 +171,7 @@ def test_read_with_no_compatible_reader():
 def test_read_with_reader_contribution_plugin(uses_sample_plugin, caplog):
     paths = ["some.fzzy"]
     chosen_reader = f"{SAMPLE_PLUGIN_NAME}.some_reader"
-    caplog.set_level(logging.WARNING, logger="npe2.io_utils")
+    caplog.set_level(logging.DEBUG, logger="npe2.io_utils")
     result = read(paths, stack=False, plugin_name=chosen_reader)
     assert result == [(None,)]
     assert any(

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import logging
+
 import pytest
 
 from npe2 import (
@@ -50,7 +52,7 @@ def test_read_with_no_plugin():
         read(paths, stack=False)
 
 
-def test_read_uses_correct_passed_plugin(tmp_path):
+def test_read_uses_correct_passed_plugin(tmp_path, caplog):
     pm = PluginManager()
     long_name = "gooby-again"
     short_name = "gooby"
@@ -79,14 +81,15 @@ def test_read_uses_correct_passed_plugin(tmp_path):
 
     # "gooby-again" isn't used even though given plugin starts with the same name
     # the reader from "gooby" returns [(None,)] which is successfully returned
-    with pytest.warns(
-        UserWarning,
-        match=rf"Reader {short_name!r} was selected .* no layers",
-    ):
-        result = io_utils._read(
-            ["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm
-        )
+    caplog.set_level(logging.WARNING, logger="npe2.io_utils")
+    result = io_utils._read(
+        ["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm
+    )
     assert result == [(None,)]
+    assert any(
+        rf"Reader {short_name!r} was selected" in rec.message
+        for rec in caplog.records
+    )
 
 
 def test_read_fails_with_refused_reader():
@@ -108,10 +111,10 @@ def test_read_fails_with_refused_reader():
         io_utils._read(["some.fzzy"], stack=False, _pm=pm)
 
 
-def test_read_succeeds_with_null_layer_and_chosen_plugin():
+def test_read_succeeds_with_null_layer_and_chosen_plugin(caplog):
     """A selected reader returning [(None,)] is valid — it signals
     'file processed successfully, nothing to add to the viewer'.
-    A UserWarning is issued when a plugin was explicitly chosen."""
+    A WARNING log message is issued when a plugin was explicitly chosen."""
     pm = PluginManager()
     plugin_name = "always-fails"
     plugin = DynamicPlugin(plugin_name, plugin_manager=pm)
@@ -124,14 +127,15 @@ def test_read_succeeds_with_null_layer_and_chosen_plugin():
     def get_read(path):
         return reader_func
 
-    with pytest.warns(
-        UserWarning,
-        match=rf"Reader {plugin_name!r} was selected .* no layers",
-    ):
-        result = io_utils._read(
-            ["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm
-        )
+    caplog.set_level(logging.WARNING, logger="npe2.io_utils")
+    result = io_utils._read(
+        ["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm
+    )
     assert result == [(None,)]
+    assert any(
+        rf"Reader {plugin_name!r} was selected" in rec.message
+        for rec in caplog.records
+    )
 
 
 def test_read_fails_with_reader_returning_none():
@@ -171,15 +175,16 @@ def test_read_with_no_compatible_reader():
         read(paths, stack=False)
 
 
-def test_read_with_reader_contribution_plugin(uses_sample_plugin):
+def test_read_with_reader_contribution_plugin(uses_sample_plugin, caplog):
     paths = ["some.fzzy"]
     chosen_reader = f"{SAMPLE_PLUGIN_NAME}.some_reader"
-    with pytest.warns(
-        UserWarning,
-        match=rf"Reader {chosen_reader!r} was selected .* no layers",
-    ):
-        result = read(paths, stack=False, plugin_name=chosen_reader)
+    caplog.set_level(logging.WARNING, logger="npe2.io_utils")
+    result = read(paths, stack=False, plugin_name=chosen_reader)
     assert result == [(None,)]
+    assert any(
+        rf"Reader {chosen_reader!r} was selected" in rec.message
+        for rec in caplog.records
+    )
 
     # if the wrong contribution is passed we get useful error message
     chosen_reader = f"{SAMPLE_PLUGIN_NAME}.not_a_reader"

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -78,11 +78,15 @@ def test_read_uses_correct_passed_plugin(tmp_path):
         return read
 
     # "gooby-again" isn't used even though given plugin starts with the same name
-    # we check that the thrown error is from "gooby" NOT "gooby-again"
-    with pytest.raises(
-        ValueError, match=f"Reader {short_name!r} was selected .* but returned no data"
+    # the reader from "gooby" returns [(None,)] which is successfully returned
+    with pytest.warns(
+        UserWarning,
+        match=rf"Reader {short_name!r} was selected .* null layer sentinel",
     ):
-        io_utils._read(["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm)
+        result = io_utils._read(
+            ["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm
+        )
+    assert result == [(None,)]
 
 
 def test_read_fails_with_refused_reader():
@@ -104,7 +108,10 @@ def test_read_fails_with_refused_reader():
         io_utils._read(["some.fzzy"], stack=False, _pm=pm)
 
 
-def test_read_fails_with_null_layer():
+def test_read_succeeds_with_null_layer_and_chosen_plugin():
+    """A selected reader returning [(None,)] is valid — it signals
+    'file processed successfully, nothing to add to the viewer'.
+    A UserWarning is issued when a plugin was explicitly chosen."""
     pm = PluginManager()
     plugin_name = "always-fails"
     plugin = DynamicPlugin(plugin_name, plugin_manager=pm)
@@ -117,10 +124,14 @@ def test_read_fails_with_null_layer():
     def get_read(path):
         return reader_func
 
-    with pytest.raises(
-        ValueError, match=f"Reader {plugin_name!r} was selected .* returned no data"
+    with pytest.warns(
+        UserWarning,
+        match=rf"Reader {plugin_name!r} was selected .* null layer sentinel",
     ):
-        io_utils._read(["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm)
+        result = io_utils._read(
+            ["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm
+        )
+    assert result == [(None,)]
 
 
 def test_read_fails_with_reader_returning_none():
@@ -163,10 +174,12 @@ def test_read_with_no_compatible_reader():
 def test_read_with_reader_contribution_plugin(uses_sample_plugin):
     paths = ["some.fzzy"]
     chosen_reader = f"{SAMPLE_PLUGIN_NAME}.some_reader"
-    with pytest.raises(
-        ValueError, match=f"Reader {chosen_reader!r} was selected .* returned no data"
+    with pytest.warns(
+        UserWarning,
+        match=rf"Reader {chosen_reader!r} was selected .* null layer sentinel",
     ):
-        read(paths, stack=False, plugin_name=chosen_reader)
+        result = read(paths, stack=False, plugin_name=chosen_reader)
+    assert result == [(None,)]
 
     # if the wrong contribution is passed we get useful error message
     chosen_reader = f"{SAMPLE_PLUGIN_NAME}.not_a_reader"

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -81,7 +81,7 @@ def test_read_uses_correct_passed_plugin(tmp_path):
     # the reader from "gooby" returns [(None,)] which is successfully returned
     with pytest.warns(
         UserWarning,
-        match=rf"Reader {short_name!r} was selected .* null layer sentinel",
+        match=rf"Reader {short_name!r} was selected .* no layers",
     ):
         result = io_utils._read(
             ["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm
@@ -126,7 +126,7 @@ def test_read_succeeds_with_null_layer_and_chosen_plugin():
 
     with pytest.warns(
         UserWarning,
-        match=rf"Reader {plugin_name!r} was selected .* null layer sentinel",
+        match=rf"Reader {plugin_name!r} was selected .* no layers",
     ):
         result = io_utils._read(
             ["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm
@@ -176,7 +176,7 @@ def test_read_with_reader_contribution_plugin(uses_sample_plugin):
     chosen_reader = f"{SAMPLE_PLUGIN_NAME}.some_reader"
     with pytest.warns(
         UserWarning,
-        match=rf"Reader {chosen_reader!r} was selected .* null layer sentinel",
+        match=rf"Reader {chosen_reader!r} was selected .* no layers",
     ):
         result = read(paths, stack=False, plugin_name=chosen_reader)
     assert result == [(None,)]

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -1,8 +1,7 @@
 # extra underscore in name to run this first
+import logging
 from pathlib import Path
 from unittest.mock import patch
-
-import logging
 
 import pytest
 
@@ -82,13 +81,10 @@ def test_read_uses_correct_passed_plugin(tmp_path, caplog):
     # "gooby-again" isn't used even though given plugin starts with the same name
     # the reader from "gooby" returns [(None,)] which is successfully returned
     caplog.set_level(logging.WARNING, logger="npe2.io_utils")
-    result = io_utils._read(
-        ["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm
-    )
+    result = io_utils._read(["some.fzzy"], plugin_name=short_name, stack=False, _pm=pm)
     assert result == [(None,)]
     assert any(
-        rf"Reader {short_name!r} was selected" in rec.message
-        for rec in caplog.records
+        rf"Reader {short_name!r} was selected" in rec.message for rec in caplog.records
     )
 
 
@@ -128,13 +124,10 @@ def test_read_succeeds_with_null_layer_and_chosen_plugin(caplog):
         return reader_func
 
     caplog.set_level(logging.WARNING, logger="npe2.io_utils")
-    result = io_utils._read(
-        ["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm
-    )
+    result = io_utils._read(["some.fzzy"], plugin_name=plugin_name, stack=False, _pm=pm)
     assert result == [(None,)]
     assert any(
-        rf"Reader {plugin_name!r} was selected" in rec.message
-        for rec in caplog.records
+        rf"Reader {plugin_name!r} was selected" in rec.message for rec in caplog.records
     )
 
 


### PR DESCRIPTION
# References and Relevant Issues

follow-up to #377
discussion on zulip starting here: https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E1/near/603315795

# Description

In #377 this moved the _is_null_layer_sentinel check to npe2.
Originally introduced in napari/napari#2206, the null layer sentinel `[(None,)]` has since then been used by plugins to signal that they have successfully processed the file but have no layer data to return. 
#377 broke part of this contract, because the check now resulted in raising a ValueError. This means that the code prior to the null_layer_sentinel would still run (like the builtin script reader or a plugin which opens a widget), but the ValueError would be raised and break tests -- causing a regression for both our script reader https://github.com/napari/napari/actions/runs/27539941390 and for plugins using the sentinel.

The goal of this check in #377 was to better inform the user about what happens, so I've opted to use the warnings.warn() machinery (from double checking against my own napari/napari#8914 notifications example) -- this will still inform the users that the sentinel was returned, but won't break plugins.

I also added lots of comments in the code because the mental flow was difficult for me, (and I did reorder the logic a bit) -- but if we don't want comments just use the first commit. 

Originallly, this was implemented as a UserWarning, but has since been moved to a logger.DEBUG