### PR TITLE
Defer unittest import

### DIFF
--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
 )
-from unittest.mock import patch
 from urllib import error, request
 from zipfile import ZipFile
 
@@ -125,6 +124,8 @@ def _build_wheel(src: str | Path) -> Path:
             kwargs["stdout"] = subprocess.DEVNULL
             kwargs["stderr"] = subprocess.DEVNULL
             super().__init__(*args, **kwargs)
+
+    from unittest.mock import patch
 
     with patch("subprocess.Popen", _QuietPopen), _guard_cwd():
         dist = Path(src) / "dist"

--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -113,6 +113,7 @@ def _guard_cwd() -> Iterator[None]:
 def _build_wheel(src: str | Path) -> Path:
     """Build a wheel from a source directory and extract it into dest."""
     from build.__main__ import build_package
+    from unittest.mock import patch
 
     dest = Path(src) / "extracted_wheel"
 
@@ -123,8 +124,6 @@ def _build_wheel(src: str | Path) -> Path:
             kwargs["stdout"] = subprocess.DEVNULL
             kwargs["stderr"] = subprocess.DEVNULL
             super().__init__(*args, **kwargs)
-
-    from unittest.mock import patch
 
     with patch("subprocess.Popen", _QuietPopen), _guard_cwd():
         dist = Path(src) / "dist"

--- a/src/npe2/_inspection/_fetch.py
+++ b/src/npe2/_inspection/_fetch.py
@@ -112,8 +112,9 @@ def _guard_cwd() -> Iterator[None]:
 
 def _build_wheel(src: str | Path) -> Path:
     """Build a wheel from a source directory and extract it into dest."""
-    from build.__main__ import build_package
     from unittest.mock import patch
+
+    from build.__main__ import build_package
 
     dest = Path(src) / "extracted_wheel"
 


### PR DESCRIPTION
Part of: https://github.com/napari/napari/issues/8689

This line in the init imports everything from _fetch when you do `import npe2` or `from npe2 import ......`:
https://github.com/napari/npe2/blob/5a0b495849ba2f3e7c423cfaaa9e2181de9fbcfc/src/npe2/__init__.py#L12

Currently, _fetch has a top-level import from unittest, which means that when you do `import npe2` or `from npe2 import ......` you pull all of `unittest` which is ~10% of overall `import npe2` time.

With the change here, to defer the unittest import until it's used (and napari doesn't use this), it can shave 10-20 ms off napari startup time.

Verified with:
`uv run python -X importtime -c "import npe2" 2>&1 | grep unittest`
 