### PR TITLE
Select writers by compound file extensions (e.g. `.ome.tiff`, `.ome.zarr`)

### DIFF
--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -698,7 +698,7 @@ class PluginManager:
         path = os.fspath(path) if path else ""
         # Match against the whole filename rather than `Path.suffix`, so a
         # compound extension like ".ome.tiff" is not shadowed by a ".tiff" writer.
-        name = os.path.basename(path).lower()
+        filename = os.path.basename(path).lower()
         has_ext = bool(Path(path).suffix)
 
         if has_ext:
@@ -710,7 +710,9 @@ class PluginManager:
                 if plugin_name and not writer.command.startswith(plugin_name):
                     continue
                 matched = [
-                    e for e in writer.filename_extensions if name.endswith(e.lower())
+                    e
+                    for e in writer.filename_extensions
+                    if filename.endswith(e.lower())
                 ]
                 if matched and (longest := max(len(e) for e in matched)) > best_len:
                     best_writer, best_len = writer, longest

--- a/src/npe2/_plugin_manager.py
+++ b/src/npe2/_plugin_manager.py
@@ -696,19 +696,35 @@ class PluginManager:
         """
         # normalise Path -> str for suffix matching and `path + ext` below
         path = os.fspath(path) if path else ""
-        ext = Path(path).suffix.lower() if path else ""
+        # Match against the whole filename rather than `Path.suffix`, so a
+        # compound extension like ".ome.tiff" is not shadowed by a ".tiff" writer.
+        name = os.path.basename(path).lower()
+        has_ext = bool(Path(path).suffix)
 
+        if has_ext:
+            # Prefer the longest matching extension; break ties by writer
+            # priority (iteration order).
+            best_writer = None
+            best_len = -1
+            for writer in self.iter_compatible_writers(layer_types):
+                if plugin_name and not writer.command.startswith(plugin_name):
+                    continue
+                matched = [
+                    e for e in writer.filename_extensions if name.endswith(e.lower())
+                ]
+                if matched and (longest := max(len(e) for e in matched)) > best_len:
+                    best_writer, best_len = writer, longest
+            return (best_writer, path) if best_writer else (None, path)
+
+        # No extension in the filename.
         for writer in self.iter_compatible_writers(layer_types):
-            if not plugin_name or writer.command.startswith(plugin_name):
-                if (ext and ext in writer.filename_extensions) or (
-                    not ext and len(layer_types) != 1 and not writer.filename_extensions
-                ):
-                    return writer, path
-                elif not ext and len(layer_types) == 1:  # No extension, single layer.
-                    ext = next(iter(writer.filename_extensions), "")
-                    return writer, path + ext
-                # When the list of extensions for the writer doesn't match the
-                # extension in the filename, keep searching.
+            if plugin_name and not writer.command.startswith(plugin_name):
+                continue
+            if len(layer_types) == 1:  # No extension, single layer.
+                ext = next(iter(writer.filename_extensions), "")
+                return writer, path + ext
+            if not writer.filename_extensions:
+                return writer, path
 
         # Nothing got found
         return None, path

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -330,6 +330,44 @@ def test_get_writer_compound_extension():
             assert out == expected_out, path
 
 
+def test_get_writer_plugin_name_and_directory():
+    """Cover plugin_name filtering (with and without an extension) and the
+    no-extension directory writer path in get_writer.
+    """
+    pm = PluginManager()
+    with (
+        DynamicPlugin(name="aaa", plugin_manager=pm) as a,
+        DynamicPlugin(name="bbb", plugin_manager=pm) as b,
+    ):
+        # "aaa" is registered first, so it is tried (and skipped) before "bbb".
+        @a.contribute.writer(filename_extensions=["*.tif"], layer_types=["image"])
+        def a_writer(path, data): ...
+
+        @b.contribute.writer(filename_extensions=["*.tif"], layer_types=["image"])
+        def b_writer(path, data): ...
+
+        # a directory writer (no extensions) that accepts several image layers
+        @b.contribute.writer(layer_types=["image{2,3}"])
+        def b_dir_writer(path, data): ...
+
+        # plugin_name skips aaa's writer even though it also matches ".tif"
+        writer, _ = pm.get_writer("x.tif", ["image"], plugin_name="bbb")
+        assert writer is not None
+        assert writer.command == "bbb.b_writer"
+
+        # plugin_name filtering on the no-extension, single-layer path
+        writer, out = pm.get_writer("noext", ["image"], plugin_name="bbb")
+        assert writer is not None
+        assert writer.command == "bbb.b_writer"
+        assert out == "noext.tif"
+
+        # no extension + multiple layers selects the directory writer
+        writer, out = pm.get_writer("some_dir", ["image", "image"])
+        assert writer is not None
+        assert writer.command == "bbb.b_dir_writer"
+        assert out == "some_dir"
+
+
 def test_writer_exec(uses_sample_plugin):
     # the sample writer knows how to handle two image layers
     result = write("test.tif", [null_image, null_image])

--- a/tests/test__io_utils.py
+++ b/tests/test__io_utils.py
@@ -286,6 +286,50 @@ def test_read_list_pathlib(uses_sample_plugin):
 null_image: FullLayerData = ([], {}, "image")
 
 
+def test_get_writer_compound_extension():
+    """Writer selection prefers the longest matching extension, so ``.ome.tiff``
+    and ``.ome.zarr`` win over higher-priority plain ``.tiff`` / ``.zarr``
+    writers. Regression test for napari/napari#9088.
+    """
+    pm = PluginManager()
+    with DynamicPlugin(name="fmt-plugin", plugin_manager=pm) as plg:
+        # Registered first, so the plain writers also have higher priority.
+        @plg.contribute.writer(
+            filename_extensions=["*.tif", "*.tiff"], layer_types=["image"]
+        )
+        def tiff_writer(path, data): ...
+
+        @plg.contribute.writer(filename_extensions=["*.zarr"], layer_types=["image"])
+        def zarr_writer(path, data): ...
+
+        @plg.contribute.writer(
+            filename_extensions=["*.ome.tif", "*.ome.tiff"], layer_types=["image"]
+        )
+        def ome_tiff_writer(path, data): ...
+
+        @plg.contribute.writer(
+            filename_extensions=["*.ome.zarr"], layer_types=["image"]
+        )
+        def ome_zarr_writer(path, data): ...
+
+        # (path, expected writer command, expected returned path)
+        cases = [
+            ("img.ome.tiff", "fmt-plugin.ome_tiff_writer", "img.ome.tiff"),
+            ("img.ome.tif", "fmt-plugin.ome_tiff_writer", "img.ome.tif"),
+            ("img.tiff", "fmt-plugin.tiff_writer", "img.tiff"),
+            ("img.tif", "fmt-plugin.tiff_writer", "img.tif"),
+            ("img.ome.zarr", "fmt-plugin.ome_zarr_writer", "img.ome.zarr"),
+            ("img.zarr", "fmt-plugin.zarr_writer", "img.zarr"),
+            # No extension: first writer wins, its default extension appended.
+            ("img", "fmt-plugin.tiff_writer", "img.tif"),
+        ]
+        for path, expected_cmd, expected_out in cases:
+            writer, out = pm.get_writer(path, ["image"])
+            assert writer is not None, f"no writer selected for {path!r}"
+            assert writer.command == expected_cmd, path
+            assert out == expected_out, path
+
+
 def test_writer_exec(uses_sample_plugin):
     # the sample writer knows how to handle two image layers
     result = write("test.tif", [null_image, null_image])


### PR DESCRIPTION
earlier, `PluginManager.get_writer` chose a writer by the final suffix only, via `Path(path).suffix`. For a path like `foo.ome.tiff` that suffix is just `.tiff`, so a writer registering `.ome.tiff` was skipped and the plain `.tiff` writer was picked instead. The same happened for `.ome.zarr` versus `.zarr`. In the save flow this means a file the user meant to save as OME-TIFF could be handed to the plain TIFF writer.

# Fix i implemented
The fix matches a writer when the filename ends with one of its declared extensions, and prefers the longest match, so `.ome.tiff` wins over `.tiff`. Ties keep the existing writer priority (iteration order). Paths without an extension are unchanged: a single layer still gets the writer's default extension appended, and multi layer saves still fall back to a directory writer.


## Testing

- Added `test_get_writer_compound_extension` in `tests/test__io_utils.py`. It registers a plain `.tif`/`.tiff` writer first and an `.ome.tif`/`.ome.tiff` writer second, then asserts that a compound path still selects the OME writer, a plain path selects the plain writer, and a path with no extension appends the default.
- Existing writer tests are unchanged and still pass.

Run:

```
uv run --extra testing pytest tests/test__io_utils.py -q
```

Resolves https://github.com/napari/napari/issues/9088