### PR TITLE
Fix CLI `--fields` option under `typer 0.27.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "tomli-w>=1.0.0",
     "tomli>=2.0.2; python_version < '3.11'",
     "rich>=14.0.0",
-    "typer>=0.15.4,< 0.27.0",
+    "typer>=0.15.4",
 ]
 
 [project.urls]

--- a/src/npe2/cli.py
+++ b/src/npe2/cli.py
@@ -237,6 +237,7 @@ def _make_rows(pm_dict: dict, normed_fields: Sequence[str]) -> Iterator[list]:
 def list_(
     fields: str = typer.Option(
         "name,version,npe2,contributions",
+        "--fields",
         help="Comma seperated list of fields to include in the output."
         "Names may contain dots, indicating nested manifest fields "
         "(`contributions.readers`). Fields names prefixed with `!` will be "


### PR DESCRIPTION
`typer 0.27.0` no longer auto-derives the long option name from the parameter name for options declared without an explicit name string, so 'npe2 list --fields ...' failed with 'No such option: --fields' and the list command exited with a usage error (exit code 2).

Declare '--fields' explicitly, matching the sibling --sort and --format options. This restores the existing public interface; no user-facing behaviour changes.