### PR TITLE
Fix napari CI job for Python 3.11 (napari dropped 3.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,11 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ./napari-from-github -c "./napari-from-github/resources/constraints/constraints_py3.10.txt"
+          python -m pip install -e ./napari-from-github -c "./napari-from-github/resources/constraints/constraints_py3.11.txt"
           python -m pip install -e .[json]
           # bare minimum required to test napari/plugins
           python -m pip install pytest pytest-pretty scikit-image[data] zarr xarray hypothesis matplotlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,11 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ./napari-from-github -c "./napari-from-github/resources/constraints/constraints_py3.11.txt"
+          python -m pip install -e ./napari-from-github -c "./napari-from-github/resources/constraints/constraints_py3.13.txt"
           python -m pip install -e .[json]
           # bare minimum required to test napari/plugins
           python -m pip install pytest pytest-pretty scikit-image[data] zarr xarray hypothesis matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "tomli-w>=1.0.0",
     "tomli>=2.0.2; python_version < '3.11'",
     "rich>=14.0.0",
-    "typer>=0.15.4",
+    "typer>=0.15.4,< 0.27.0",
 ]
 
 [project.urls]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_cli_validate_ok(sample_path, debug, imports, monkeypatch):
         m.setattr(sys, "path", [*sys.path, str(sample_path)])
         result = runner.invoke(app, cmd)
     assert "✔ Manifest for 'My Plugin' valid!" in result.stdout
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output_bytes
 
 
 def test_cli_validate_invalid(tmp_path, capsys):
@@ -184,7 +184,7 @@ def test_cli_cache_clear_named(mock_cache):
 )
 def test_cli_list(format, fields, uses_npe1_plugin):
     result = runner.invoke(app, ["list", "-f", format, "--fields", fields])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output_bytes
     assert "npe1-plugin" in result.output
     if fields and "author" in fields and format != "compact":
         assert "author" in result.output.lower()


### PR DESCRIPTION
The test_napari job installs napari from its main branch using a constraints file pinned to Python 3.10. napari dropped Python 3.10 in napari/napari#9104, deleting resources/constraints/constraints_py3.10.txt, so the install step failed with 'Could not open constraint file'.

Bump the job to Python 3.11 (napari's current minimum) and reference the matching constraints_py3.11.txt. npe2's own test matrix still covers 3.10 and is unchanged.