### PR TITLE
Remove title from configuration contribution

### DIFF
--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -132,12 +132,6 @@ class ConfigurationContribution(BaseModel):
     Configuration contributions are used to generate the settings UI.
     """
 
-    title: str = Field(
-        ...,
-        description="The heading used for this configuration category. Words like "
-        '"Plugin", "Configuration", and "Settings" are redundant and should not be'
-        "used in your title.",
-    )
     properties: dict[str, ConfigurationProperty] = Field(
         ...,
         description="Configuration properties. In the settings UI, your configuration "

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -45,16 +45,7 @@ class ContributionPoints(BaseModel):
     submenus: list[SubmenuContribution] | None = None
     keybindings: list[KeyBindingContribution] | None = Field(None, hide_docs=True)
 
-    configuration: list[ConfigurationContribution] = Field(
-        default_factory=list,
-        hide_docs=True,
-        description="Configuration options for this plugin."
-        "This section can either be a single object, representing a single category of"
-        "settings, or an array of objects, representing multiple categories of"
-        "settings. If there are multiple categories of settings, the Settings editor"
-        "will show a submenu in the table of contents for that extension, and the title"
-        "keys will be used for the submenu entry names.",
-    )
+    configuration: ConfigurationContribution|None = None
 
     @field_validator("configuration", mode="before")
     @classmethod

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -45,7 +45,7 @@ class ContributionPoints(BaseModel):
     submenus: list[SubmenuContribution] | None = None
     keybindings: list[KeyBindingContribution] | None = Field(None, hide_docs=True)
 
-    configuration: ConfigurationContribution|None = None
+    configuration: ConfigurationContribution | None = None
 
     @field_validator("configuration", mode="before")
     @classmethod

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -45,7 +45,16 @@ class ContributionPoints(BaseModel):
     submenus: list[SubmenuContribution] | None = None
     keybindings: list[KeyBindingContribution] | None = Field(None, hide_docs=True)
 
-    configuration: ConfigurationContribution | None = None
+    configuration: list[ConfigurationContribution] = Field(
+        default_factory=list,
+        hide_docs=True,
+        description="Configuration options for this plugin."
+        "This section can either be a single object, representing a single category of"
+        "settings, or an array of objects, representing multiple categories of"
+        "settings. If there are multiple categories of settings, the Settings editor"
+        "will show a submenu in the table of contents for that extension, and the title"
+        "keys will be used for the submenu entry names.",
+    )
 
     @field_validator("configuration", mode="before")
     @classmethod

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -31,8 +31,7 @@ contributions:
       title: Create widget from my function
       python_name: my_plugin:make_widget_from_function
   configuration:
-    - title: My Plugin
-      properties:
+    - properties:
         my_plugin.reader.lazy:
           type: boolean
           default: false

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -21,10 +21,8 @@ PROPS = [
 @pytest.mark.parametrize("props", PROPS)
 def test_config_contribution(props):
     cc = ConfigurationContribution(
-        title="My Plugin",
         properties=props,
     )
-    assert cc.title == "My Plugin"
     for key, val in cc.properties.items():
         assert val.model_dump(exclude_unset=True, by_alias=True) == props[key]
 


### PR DESCRIPTION
Configuration settings should not have a title in the manifest, as it should inherit the title of the whole plugin