### PR TITLE
Unify configuration schema and greatly simplify fields

### DIFF
--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, BeforeValidator, Field, conlist, model_validator
 from ._json_schema import (
     ConfigurationJsonSchema,
     JsonType,
-    _coerce_type_name,
+    _to_json_type,
 )
 
 
@@ -16,7 +16,7 @@ class ConfigurationProperty(ConfigurationJsonSchema):
     https://json-schema.org/understanding-json-schema/reference
     """
 
-    type: Annotated[JsonType, BeforeValidator(_coerce_type_name)] = Field(
+    type: Annotated[JsonType, BeforeValidator(_to_json_type)] = Field(
         description="The type of this variable. Either a JSON Schema type name "
         "('boolean', 'integer', 'number', 'string') or a python type name "
         "('bool', 'int', 'float', 'str') may be used, but it will be "

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -3,14 +3,14 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, BeforeValidator, Field, conlist, model_validator
 
 from ._json_schema import (
-    Draft07JsonSchema,
+    ConfigurationJsonSchema,
     JsonType,
     JsonTypeArray,
     _coerce_type_name,
 )
 
 
-class ConfigurationProperty(Draft07JsonSchema):
+class ConfigurationProperty(ConfigurationJsonSchema):
     """Configuration for a single property in the plugin settings.
 
     This is a super-set of the JSON Schema (draft 7) specification.
@@ -21,13 +21,11 @@ class ConfigurationProperty(Draft07JsonSchema):
         Field(
             None,
             description="The type of this variable. Either JSON Schema type names "
-            "('array', 'boolean', 'object', ...) or python type names ('list', 'bool', "
-            "'dict', ...) may be used, but they will be coerced to JSON Schema types. "
-            "Numbers, strings, and booleans will be editable in the UI, other types "
-            "(lists, dicts) *may* be editable in the UI depending on their content, "
-            "but maby will only be editable as text in the napari settings file. For "
-            "boolean entries, the description (or markdownDescription) will be used as"
-            " the label for the checkbox.",
+            "('boolean', 'integer', 'number', 'string', 'null') or python type names "
+            "('bool', 'int', 'float', 'str', 'None') may be used, but they will be "
+            "coerced to JSON Schema types. Numbers, strings, and booleans will be "
+            "editable in the UI. For boolean entries, the description (or "
+            "markdownDescription) will be used as the label for the checkbox.",
         )
     )
 
@@ -38,12 +36,6 @@ class ConfigurationProperty(Draft07JsonSchema):
         description="Your `description` appears after the title and before the input "
         "field, except for booleans, where the description is used as the label for "
         "the checkbox. See also `markdown_description`.",
-    )
-    description_format: Literal["markdown", "plain"] = Field(
-        "markdown",
-        description="By default (`markdown`) your `description`, will be parsed "
-        "as CommonMark (with `markdown_it`) and rendered as rich text. To render as "
-        "plain text, set this value to `plain`.",
     )
 
     enum: conlist(Any, min_length=1) | None = Field(  # type: ignore
@@ -56,12 +48,6 @@ class ConfigurationProperty(Draft07JsonSchema):
         description="If you provide a list of items under the `enum` field, you may "
         "provide `enum_descriptions` to add descriptive text for each enum.",
     )
-    enum_descriptions_format: Literal["markdown", "plain"] = Field(
-        "markdown",
-        description="By default (`markdown`) your `enum_description`s, will be parsed "
-        "as CommonMark (with `markdown_it`) and rendered as rich text. To render as "
-        "plain text, set this value to `plain`.",
-    )
 
     deprecation_message: str | None = Field(
         None,
@@ -69,31 +55,10 @@ class ConfigurationProperty(Draft07JsonSchema):
         "underline with your specified message. It won't show up in the settings "
         "UI unless it is configured by the user.",
     )
-    deprecation_message_format: Literal["markdown", "plain"] = Field(
-        "markdown",
-        description="By default (`markdown`) your `deprecation_message`, will be "
-        "parsed as CommonMark (with `markdown_it`) and rendered as rich text. To "
-        "render as plain text, set this value to `plain`.",
-    )
-
     edit_presentation: Literal["singleline", "multiline"] = Field(
         "singleline",
         description="By default, string settings will be rendered with a single-line "
         "editor. To render with a multi-line editor, set this value to `multiline`.",
-    )
-    order: int | None = Field(
-        None,
-        description="When specified, gives the order of this setting relative to other "
-        "settings within the same category. Settings with an order property will be "
-        "placed before settings without this property set; and settings without `order`"
-        " will be placed in alphabetical order.",
-    )
-
-    pattern_error_message: str | None = Field(
-        None,
-        description="When restricting string types to a given regular expression with "
-        "the `pattern` field, this field may be used to provide a custom error when "
-        "the pattern does not match.",
     )
 
     @model_validator(mode="before")
@@ -112,17 +77,6 @@ class ConfigurationProperty(Draft07JsonSchema):
                     stacklevel=2,
                 )
         return values
-
-    def validate_instance(self, instance: object) -> dict:
-        """Validate an object (instance) against this schema."""
-        from ._json_schema import ValidationError as JsonSchemaValidationError
-
-        try:
-            return super().validate_instance(instance)
-        except JsonSchemaValidationError as e:
-            if e.validator == "pattern" and self.pattern_error_message:
-                e.message = self.pattern_error_message
-            raise e
 
 
 class ConfigurationContribution(BaseModel):

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, BeforeValidator, Field, conlist, model_validator
 from ._json_schema import (
     ConfigurationJsonSchema,
     JsonType,
-    JsonTypeArray,
     _coerce_type_name,
 )
 
@@ -17,15 +16,13 @@ class ConfigurationProperty(ConfigurationJsonSchema):
     https://json-schema.org/understanding-json-schema/reference
     """
 
-    type: Annotated[JsonType | JsonTypeArray, BeforeValidator(_coerce_type_name)] = (
-        Field(
-            description="The type of this variable. Either JSON Schema type names "
-            "('boolean', 'integer', 'number', 'string') or python type names "
-            "('bool', 'int', 'float', 'str') may be used, but they will be "
-            "coerced to JSON Schema types. Numbers, strings, and booleans will be "
-            "editable in the UI. For boolean entries, the description "
-            "will be used as the label for the checkbox.",
-        )
+    type: Annotated[JsonType, BeforeValidator(_coerce_type_name)] = Field(
+        description="The type of this variable. Either a JSON Schema type name "
+        "('boolean', 'integer', 'number', 'string') or a python type name "
+        "('bool', 'int', 'float', 'str') may be used, but it will be "
+        "coerced to a JSON Schema type. Numbers, strings, and booleans will be "
+        "editable in the UI. For boolean entries, the description "
+        "will be used as the label for the checkbox.",
     )
 
     default: Any = Field(None, description="The default value for this property.")

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, Field, conlist, model_validator
 
@@ -54,10 +54,10 @@ class ConfigurationProperty(ConfigurationJsonSchema):
         "underline with your specified message. It won't show up in the settings "
         "UI unless it is configured by the user.",
     )
-    edit_presentation: Literal["singleline", "multiline"] = Field(
-        "singleline",
+    is_multiline: bool = Field(
+        False,
         description="By default, string settings will be rendered with a single-line "
-        "editor. To render with a multi-line editor, set this value to `multiline`.",
+        "editor. To render with a multi-line editor, set this value to `True`.",
     )
 
     @model_validator(mode="before")

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -13,19 +13,18 @@ from ._json_schema import (
 class ConfigurationProperty(ConfigurationJsonSchema):
     """Configuration for a single property in the plugin settings.
 
-    This is a super-set of the JSON Schema (draft 7) specification.
-    https://json-schema.org/understanding-json-schema/reference/index.html
+    This is a subset of the JSON Schema (draft 2020-12) specification.
+    https://json-schema.org/understanding-json-schema/reference
     """
 
     type: Annotated[JsonType | JsonTypeArray, BeforeValidator(_coerce_type_name)] = (
         Field(
-            None,
             description="The type of this variable. Either JSON Schema type names "
-            "('boolean', 'integer', 'number', 'string', 'null') or python type names "
-            "('bool', 'int', 'float', 'str', 'None') may be used, but they will be "
+            "('boolean', 'integer', 'number', 'string') or python type names "
+            "('bool', 'int', 'float', 'str') may be used, but they will be "
             "coerced to JSON Schema types. Numbers, strings, and booleans will be "
-            "editable in the UI. For boolean entries, the description (or "
-            "markdownDescription) will be used as the label for the checkbox.",
+            "editable in the UI. For boolean entries, the description "
+            "will be used as the label for the checkbox.",
         )
     )
 
@@ -35,7 +34,7 @@ class ConfigurationProperty(ConfigurationJsonSchema):
         None,
         description="Your `description` appears after the title and before the input "
         "field, except for booleans, where the description is used as the label for "
-        "the checkbox. See also `markdown_description`.",
+        "the checkbox",
     )
 
     enum: conlist(Any, min_length=1) | None = Field(  # type: ignore

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -37,7 +37,6 @@ __all__ = [
 ]
 
 JsonType = Literal["boolean", "integer", "number", "string"]
-JsonTypeArray = conlist(JsonType, min_length=1)
 
 PY_NAME_TO_JSON_NAME = {
     "bool": "boolean",
@@ -56,8 +55,6 @@ def _to_json_type(type_: str | type) -> JsonType:
 
 def _coerce_type_name(v):
     """Coerce python type names to json schema type names."""
-    if isinstance(v, list):
-        return [_to_json_type(t) for t in v]
     return _to_json_type(v)
 
 
@@ -108,9 +105,7 @@ class ConfigurationJsonSchema(BaseModel):
     title: str | None = Field(None)
     description: str | None = Field(None)
     default: Any = Field(None)
-    type: Annotated[JsonType | JsonTypeArray, BeforeValidator(_coerce_type_name)] = (  # type: ignore
-        Field()
-    )
+    type: Annotated[JsonType, BeforeValidator(_coerce_type_name)] = Field()
     # constraints to specific choices
     enum: conlist(Any, min_length=1) | None = Field(None)  # type: ignore
 
@@ -151,12 +146,9 @@ class ConfigurationJsonSchema(BaseModel):
         return "default" in self.model_fields_set
 
     @property
-    def python_type(self) -> builtins.type | list[builtins.type]:
-        """Return Python type equivalent(s) for this schema (JSON) type."""
-        if isinstance(self.type, list):
-            return [_python_equivalent[t] for t in self.type]
-        else:
-            return _python_equivalent[self.type]
+    def python_type(self) -> builtins.type:
+        """Return the Python type equivalent for this schema's (JSON) type."""
+        return _python_equivalent[self.type]
 
     @property
     def json_validator(self) -> builtins.type[Validator]:

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -53,11 +53,6 @@ def _to_json_type(type_: str | type) -> JsonType:
     return PY_NAME_TO_JSON_NAME.get(type_, type_)  # type: ignore # (validated later)
 
 
-def _coerce_type_name(v):
-    """Coerce python type names to json schema type names."""
-    return _to_json_type(v)
-
-
 def _to_camel(string: str) -> str:
     words = string.split("_")
     return words[0] + "".join(w.capitalize() for w in words[1:])
@@ -105,7 +100,7 @@ class ConfigurationJsonSchema(BaseModel):
     title: str | None = Field(None)
     description: str | None = Field(None)
     default: Any = Field(None)
-    type: Annotated[JsonType, BeforeValidator(_coerce_type_name)] = Field()
+    type: Annotated[JsonType, BeforeValidator(_to_json_type)] = Field()
     # constraints to specific choices
     enum: conlist(Any, min_length=1) | None = Field(None)  # type: ignore
 

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -84,12 +84,11 @@ _CONSTRAINT_FIELDS = {
     "max_length",
 }
 
-_python_equivalent: dict[str | None, type] = {
+_python_equivalent: dict[str, type] = {
     "boolean": bool,
     "integer": int,
     "number": float,
     "string": str,
-    None: object,
 }
 
 

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -36,7 +36,7 @@ __all__ = [
     "ValidationError",
 ]
 
-JsonType = Literal["boolean", "integer", "null", "number", "string"]
+JsonType = Literal["boolean", "integer", "number", "string"]
 JsonTypeArray = conlist(JsonType, min_length=1)
 
 PY_NAME_TO_JSON_NAME = {
@@ -44,8 +44,6 @@ PY_NAME_TO_JSON_NAME = {
     "int": "integer",
     "float": "number",
     "str": "string",
-    "NoneType": "null",
-    "None": "null",
 }
 
 
@@ -89,7 +87,6 @@ _CONSTRAINT_FIELDS = {
 _python_equivalent: dict[str | None, type] = {
     "boolean": bool,
     "integer": int,
-    "null": type(None),
     "number": float,
     "string": str,
     None: object,

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -110,7 +110,7 @@ class ConfigurationJsonSchema(BaseModel):
     description: str | None = Field(None)
     default: Any = Field(None)
     type: Annotated[JsonType | JsonTypeArray, BeforeValidator(_coerce_type_name)] = (  # type: ignore
-        Field(None)
+        Field()
     )
     # constraints to specific choices
     enum: conlist(Any, min_length=1) | None = Field(None)  # type: ignore

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -32,23 +32,17 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = [
-    "Draft04JsonSchema",
-    "Draft06JsonSchema",
-    "Draft07JsonSchema",
+    "ConfigurationJsonSchema",
     "ValidationError",
 ]
 
-JsonType = Literal["array", "boolean", "integer", "null", "number", "object", "string"]
+JsonType = Literal["boolean", "integer", "null", "number", "string"]
 JsonTypeArray = conlist(JsonType, min_length=1)
-StringArrayMin1 = conlist(str, min_length=1)
-StringArray = conlist(str)
 
 PY_NAME_TO_JSON_NAME = {
-    "list": "array",
     "bool": "boolean",
     "int": "integer",
     "float": "number",
-    "dict": "object",
     "str": "string",
     "NoneType": "null",
     "None": "null",
@@ -88,76 +82,65 @@ _CONSTRAINT_FIELDS = {
     "exclusive_maximum",
     "maximum",
     "multiple_of",
-    "min_items",
-    "max_items",
     "min_length",
     "max_length",
-    "pattern",
 }
 
 _python_equivalent: dict[str | None, type] = {
-    "array": list,
     "boolean": bool,
     "integer": int,
     "null": type(None),
     "number": float,
-    "object": dict,
     "string": str,
     None: object,
 }
 
 
-class _JsonSchemaBase(BaseModel):
+class ConfigurationJsonSchema(BaseModel):
+    """Model for (a subset of) Draft 2020-12 JSON Schema.
+
+    This is the schema model used for the `configuration` contribution.
+    https://json-schema.org/understanding-json-schema/reference
+    """
+
     model_config = ConfigDict(alias_generator=TO_CAMEL, validate_by_name=True)
 
     # underscore here to avoid name collision with pydantic's `schema` method
-    schema_: str | None = Field(None, alias="$schema")
+    schema_: str = Field(
+        "https://json-schema.org/draft/2020-12/schema", alias="$schema"
+    )
     title: str | None = Field(None)
     description: str | None = Field(None)
     default: Any = Field(None)
-    multiple_of: float | None = Field(None, ge=0)
-    maximum: float | None = Field(None)
-    minimum: float | None = Field(None)
-    max_length: int | None = Field(None, ge=0)
-    min_length: int | None = Field(0, ge=0)
-    # could be Pattern. but it's easier to work with as str
-    pattern: str | None = Field(None)
-    max_items: int | None = Field(None, ge=0)
-    min_items: int | None = Field(0, ge=0)
-    unique_items: bool = Field(False)
-    max_properties: int | None = Field(None, ge=0)
-    min_properties: int | None = Field(0, ge=0)
-    enum: conlist(Any, min_length=1) | None = Field(None)  # type: ignore
     type: Annotated[JsonType | JsonTypeArray, BeforeValidator(_coerce_type_name)] = (  # type: ignore
         Field(None)
     )
-    format: str | None = Field(None)
+    # constraints to specific choices
+    enum: conlist(Any, min_length=1) | None = Field(None)  # type: ignore
+
+    # min/max value for a property with type float or int
+    minimum: float | int | None = Field(None)
+    maximum: float | int | None = Field(None)
+
+    # allows you to define an open interval
+    exclusive_maximum: float | int | None = Field(None)
+    exclusive_minimum: float | int | None = Field(None)
+    # allows you to constrain number to be a multiple
+    multiple_of: float | int | None = Field(None, ge=0)
+
+    # min/max length for a property with type string
+    max_length: int | None = Field(None, ge=0)
+    min_length: int | None = Field(0, ge=0)
 
     _json_validator: builtins.type[Validator] = PrivateAttr()
 
-    # these will be redefined in subclasses with specific subschema types
-    # just here for type-checking in the methods of this base class
-    if TYPE_CHECKING:
-        items: Any
-        properties: Any
-        all_of: Any
-        any_of: Any
-        one_of: Any
-
     @model_validator(mode="before")
     def _validate_root(cls, values: dict[str, Any]) -> Any:
-        if "type" not in values:
-            if "properties" in values:
-                values["type"] = "object"
-            elif "items" in values:
-                values["type"] = "array"
-
         # TODO: is this still true?
         # Get around pydantic bug wherein `Optional[conlists]`` throw a
         # 'NoneType' object is not iterable error if `None` is provided in init.
-        for conlists in ("enum", "required"):
-            if conlists in values and not values[conlists]:
-                values.pop(conlists)
+        if "enum" in values and not values["enum"]:
+            values.pop("enum")
 
         return values
 
@@ -178,22 +161,6 @@ class _JsonSchemaBase(BaseModel):
             return [_python_equivalent[t] for t in self.type]
         else:
             return _python_equivalent[self.type]
-
-    @property
-    def is_array(self) -> bool:
-        """Return True if this schema is an array schema."""
-        return self.items is not None or self.type == "array"
-
-    @property
-    def is_object(self) -> bool:
-        """Return True if this schema is an object schema."""
-        return self.properties is not None or (
-            self.type == "object"
-            and not self.all_of
-            and not self.one_of
-            and not self.any_of
-            and not getattr(self, "ref", False)
-        )  # draft 6+
 
     @property
     def json_validator(self) -> builtins.type[Validator]:
@@ -219,90 +186,3 @@ class _JsonSchemaBase(BaseModel):
         if error is not None:
             raise error
         return instance
-
-
-class Draft04JsonSchema(_JsonSchemaBase):
-    """Model for Draft 4 JSON Schema."""
-
-    schema_: str = Field("http://json-schema.org/draft-04/schema#", alias="$schema")
-    id: str | None = Field(None)
-    exclusive_maximum: bool | None = Field(None)
-    exclusive_minimum: bool | None = Field(None)
-    required: StringArrayMin1 | None = Field(None)  # type: ignore
-    dependencies: dict[str, Draft04JsonSchema | StringArrayMin1] | None = Field(None)  # type: ignore
-
-    # common to all schemas (could go in _JsonSchemaBase)
-    # except we need the self-referrential type to be this class
-    additional_items: bool | Draft04JsonSchema | None = Field(None)
-    items: Draft04JsonSchema | list[Draft04JsonSchema] | None = Field(None)
-    additional_properties: bool | Draft04JsonSchema | None = Field(None)
-    definitions: dict[str, Draft04JsonSchema] | None = Field(None)
-    properties: dict[str, Draft04JsonSchema] | None = Field(None)
-    pattern_properties: dict[str, Draft04JsonSchema] | None = Field(None)
-    all_of: list[Draft04JsonSchema] | None = Field(None)
-    any_of: list[Draft04JsonSchema] | None = Field(None)
-    one_of: list[Draft04JsonSchema] | None = Field(None)
-    not_: Draft04JsonSchema | None = Field(None, alias="not")
-
-
-class _Draft06JsonSchema(_JsonSchemaBase):
-    id: str | None = Field(None, alias="$id")
-    # ref: Optional[str] = Field(None, alias="$ref")
-    examples: list[Any] | None = Field(None)
-    exclusive_maximum: float | None = Field(None)
-    exclusive_minimum: float | None = Field(None)
-    contains: Draft06JsonSchema | None = Field(None)
-    required: StringArray | None = Field(None)  # type: ignore
-    dependencies: dict[str, Draft06JsonSchema | StringArray] | None = Field(None)  # type: ignore
-    property_names: Draft06JsonSchema | None = Field(None)
-    const: Any = Field(None)
-
-
-class Draft06JsonSchema(_Draft06JsonSchema):
-    """Model for Draft 6 JSON Schema."""
-
-    schema_: str = Field("http://json-schema.org/draft-06/schema#", alias="$schema")
-
-    # common to all schemas (could go in _JsonSchemaBase)
-    # except we need the self-referrential type to be this class
-    # and... technically, all subschemas may also be booleans as of Draft 6,
-    # not just additional_properties and additional_items
-    additional_items: bool | Draft06JsonSchema | None = Field(None)
-    items: Draft06JsonSchema | list[Draft06JsonSchema] | None = Field(None)
-    additional_properties: bool | Draft06JsonSchema | None = Field(None)
-    # definitions: Optional[Dict[str, Draft06JsonSchema]] = Field(None)
-    properties: dict[str, Draft06JsonSchema] | None = Field(None)
-    pattern_properties: dict[str, Draft06JsonSchema] | None = Field(None)
-    all_of: list[Draft06JsonSchema] | None = Field(None)
-    any_of: list[Draft06JsonSchema] | None = Field(None)
-    one_of: list[Draft06JsonSchema] | None = Field(None)
-    not_: Draft06JsonSchema | None = Field(None, alias="not")
-
-
-class Draft07JsonSchema(_Draft06JsonSchema):
-    """Model for Draft 7 JSON Schema."""
-
-    schema_: str = Field("http://json-schema.org/draft-07/schema#", alias="$schema")
-    comment: str | None = Field(None, alias="$comment")
-    read_only: bool = Field(False)
-    write_only: bool = Field(False)
-    content_media_type: str | None = Field(None)
-    content_encoding: str | None = Field(None)
-    if_: Draft07JsonSchema | None = Field(None, alias="if")
-    then: Draft07JsonSchema | None = Field(None)
-    else_: Draft07JsonSchema | None = Field(None, alias="else")
-
-    # common to all schemas (could go in _JsonSchemaBase)
-    # except we need the self-referrential type to be this class
-    # and... technically, all subschemas may also be booleans as of Draft 6,
-    # not just additional_properties and additional_items
-    additional_items: bool | Draft07JsonSchema | None = Field(None)
-    items: Draft07JsonSchema | list[Draft07JsonSchema] | None = Field(None)
-    additional_properties: bool | Draft07JsonSchema | None = Field(None)
-    # definitions: Optional[Dict[str, Draft07JsonSchema]] = Field(None)
-    properties: dict[str, Draft07JsonSchema] | None = Field(None)
-    pattern_properties: dict[str, Draft07JsonSchema] | None = Field(None)
-    all_of: list[Draft07JsonSchema] | None = Field(None)
-    any_of: list[Draft07JsonSchema] | None = Field(None)
-    one_of: list[Draft07JsonSchema] | None = Field(None)
-    not_: Draft07JsonSchema | None = Field(None, alias="not")

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -40,15 +40,6 @@ def test_warn_on_refs_defs():
 
 
 CASES = [
-    (
-        {
-            "type": str,
-            "pattern": "^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$",
-            "pattern_error_message": "custom error",
-        },
-        "555-1212",
-        "(888)555-1212 ext. 532",
-    ),
     ({"type": "string", "minLength": 2}, "AB", "A"),
     ({"type": "string", "maxLength": 3}, "AB", "ABCD"),
     ({"type": "integer"}, 42, 3.123),
@@ -56,36 +47,6 @@ CASES = [
     ({"type": int, "multipleOf": 10}, 30, 23),
     ({"type": "number", "minimum": 100}, 100, 99),
     ({"type": "number", "exclusiveMaximum": 100}, 99, 100),
-    (
-        {"properties": {"number": {"type": "number"}}},
-        {"number": 1600},
-        {"number": "1600"},
-    ),
-    (
-        {
-            "type": dict,
-            "properties": {
-                "number": {"type": "number"},
-            },
-            "additional_properties": False,
-        },
-        {"number": 1600},
-        {"number": 1600, "street_name": "Pennsylvania"},
-    ),
-    ({"type": "array"}, [3, "diff", {"types": "of values"}], {"Not": "an array"}),
-    ({"items": {"type": "number"}}, [1, 2, 3, 4, 5], [1, 2, "3", 4, 5]),
-    (
-        {
-            "items": [
-                {"type": "number"},
-                {"type": "string"},
-                {"enum": ["Street", "Avenue", "Boulevard"]},
-                {"enum": ["NW", "NE", "SW", "SE"]},
-            ]
-        },
-        [1600, "Pennsylvania", "Avenue", "NW"],
-        [24, "Sussex", "Drive"],
-    ),
     ({"type": [bool, int]}, True, "True"),
 ]
 
@@ -95,12 +56,9 @@ def test_config_validation(schema, valid, invalid):
     cfg = ConfigurationProperty(**schema)
     assert cfg.validate_instance(valid) == valid
 
-    match = schema.get("pattern_error_message", None)
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValidationError):
         cfg.validate_instance(invalid)
 
-    assert cfg.is_array is ("items" in schema or cfg.type == "array")
-    assert cfg.is_object is (cfg.type == "object")
     assert isinstance(cfg.has_constraint, bool)
 
     # check that we can can convert json type to python type

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -47,7 +47,6 @@ CASES = [
     ({"type": int, "multipleOf": 10}, 30, 23),
     ({"type": "number", "minimum": 100}, 100, 99),
     ({"type": "number", "exclusiveMaximum": 100}, 99, 100),
-    ({"type": [bool, int]}, True, "True"),
 ]
 
 
@@ -61,9 +60,6 @@ def test_config_validation(schema, valid, invalid):
 
     assert isinstance(cfg.has_constraint, bool)
 
-    # check that we can can convert json type to python type
-    for t in (
-        cfg.python_type if isinstance(cfg.python_type, list) else [cfg.python_type]
-    ):
-        assert t.__module__ == "builtins"
+    # check that we can convert json type to python type
+    assert cfg.python_type.__module__ == "builtins"
     assert cfg.has_default is ("default" in schema)


### PR DESCRIPTION
This PR:

- Removes unused Draft04 and Draft06 JsonSchema models
- Renames Draft07 JsonSchema to simply "ConfigurationJsonSchema", and links to the most recent version of the schema, 2020-12. I confirmed we are a compatible subset of that schema format
- Removes a bunch of configuration property fields that are unlikely to be useful for plugin settings:
   - Object-type properties and associated constraint fields
   - Array-type properties and associated constraint fields
   - Properties related to composable schemas (not, any_of, etc.)
   - None-type properties (typically used in composed schemas)
   - Const-type properties (typically used in composed schemas)
 - Removes some constraint fields from property types we did keep:
   - We won't support pattern-validation for string types
   - We won't support format-validation for string types (emails etc.)
 - Removes unnecessary ConfigurationProperty fields -- mostly fields that allow the user to specify whether some text is markdown or plain formatted

What didn't you remove?!

- Boolean, enum, string, integer and float-type configuration properties
- Constraints on integer/float-type properties (min/max/exclusive_min/exclusive_max/multiple_of)
- Constraining a string to a min/max length
- Setting a deprecation_message for a property