### PR TITLE
Fully document all `ConfigurationJsonSchema` and `ConfigurationProperty` fields

### DIFF
--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -1,44 +1,16 @@
-from typing import Annotated, Any
+from pydantic import BaseModel, Field, model_validator
 
-from pydantic import BaseModel, BeforeValidator, Field, conlist, model_validator
-
-from ._json_schema import (
-    ConfigurationJsonSchema,
-    JsonType,
-    _to_json_type,
-)
+from ._json_schema import ConfigurationJsonSchema
 
 
 class ConfigurationProperty(ConfigurationJsonSchema):
     """Configuration for a single property in the plugin settings.
 
     This is a subset of the JSON Schema (draft 2020-12) specification.
-    https://json-schema.org/understanding-json-schema/reference
+    https://json-schema.org/draft/2020-12/ with some additional fields
+    for the settings UI.
     """
 
-    type: Annotated[JsonType, BeforeValidator(_to_json_type)] = Field(
-        description="The type of this variable. Either a JSON Schema type name "
-        "('boolean', 'integer', 'number', 'string') or a python type name "
-        "('bool', 'int', 'float', 'str') may be used, but it will be "
-        "coerced to a JSON Schema type. Numbers, strings, and booleans will be "
-        "editable in the UI. For boolean entries, the description "
-        "will be used as the label for the checkbox.",
-    )
-
-    default: Any = Field(None, description="The default value for this property.")
-
-    description: str | None = Field(
-        None,
-        description="Your `description` appears after the title and before the input "
-        "field, except for booleans, where the description is used as the label for "
-        "the checkbox",
-    )
-
-    enum: conlist(Any, min_length=1) | None = Field(  # type: ignore
-        None,
-        description="A list of valid options for this field. If you provide this field,"
-        "the settings UI will render a dropdown menu.",
-    )
     enum_descriptions: list[str] = Field(
         default_factory=list,
         description="If you provide a list of items under the `enum` field, you may "

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -95,28 +95,82 @@ class ConfigurationJsonSchema(BaseModel):
 
     # underscore here to avoid name collision with pydantic's `schema` method
     schema_: str = Field(
-        "https://json-schema.org/draft/2020-12/schema", alias="$schema"
+        "https://json-schema.org/draft/2020-12/schema",
+        alias="$schema",
+        description="Identifies the JSON Schema dialect this document conforms to. "
+        "Applies to the schema itself, not to any particular instance type.",
     )
-    title: str | None = Field(None)
-    description: str | None = Field(None)
-    default: Any = Field(None)
-    type: Annotated[JsonType, BeforeValidator(_to_json_type)] = Field()
-    # constraints to specific choices
-    enum: conlist(Any, min_length=1) | None = Field(None)  # type: ignore
+    title: str | None = Field(
+        None,
+        description="The title of this configuration property. This will be displayed "
+        "in the settings UI as the label for this property.",
+    )
+    description: str | None = Field(
+        None,
+        description="Your `description` appears after the title and before the input "
+        "field, except for booleans, where the description is used as the label for "
+        "the checkbox",
+    )
 
+    type: Annotated[JsonType, BeforeValidator(_to_json_type)] = Field(
+        description="The type of this variable. Either a JSON Schema type name "
+        "('boolean', 'integer', 'number', 'string') or a python type name "
+        "('bool', 'int', 'float', 'str') may be used, but it will be "
+        "coerced to a JSON Schema type. For boolean entries, the description "
+        "will be used as the label for the checkbox.",
+    )
+    default: Any = Field(None, description="The default value for this property.")
+    enum: conlist(Any, min_length=1) | None = Field(  # type: ignore
+        None,
+        description="A list of valid options for this field. If you provide this field,"
+        "the settings UI will render a dropdown menu. Enum members must be of the same "
+        "type as the `type` field.",
+    )
     # min/max value for a property with type float or int
-    minimum: float | int | None = Field(None)
-    maximum: float | int | None = Field(None)
+    minimum: float | int | None = Field(
+        None,
+        description="The inclusive lower bound: the value must be greater than or "
+        "equal to this number. Only valid for `integer` or `number` types.",
+    )
+    maximum: float | int | None = Field(
+        None,
+        description="The inclusive upper bound: the value must be less than or "
+        "equal to this number. Only valid for `integer` or `number` types.",
+    )
 
     # allows you to define an open interval
-    exclusive_maximum: float | int | None = Field(None)
-    exclusive_minimum: float | int | None = Field(None)
+    exclusive_maximum: float | int | None = Field(
+        None,
+        description="The exclusive upper bound: the value must be strictly less "
+        "than this number. Only valid for `integer` or `number` types.",
+    )
+    exclusive_minimum: float | int | None = Field(
+        None,
+        description="The exclusive lower bound: the value must be strictly greater "
+        "than this number. Only valid for `integer` or `number` types.",
+    )
     # allows you to constrain number to be a multiple
-    multiple_of: float | int | None = Field(None, ge=0)
+    multiple_of: float | int | None = Field(
+        None,
+        ge=0,
+        description="Restricts the value to an integer multiple of this number "
+        "(e.g. `multiple_of: 5` allows 0, 5, 10, ...). Only valid for `integer` or "
+        "`number` types.",
+    )
 
     # min/max length for a property with type string
-    max_length: int | None = Field(None, ge=0)
-    min_length: int | None = Field(0, ge=0)
+    max_length: int | None = Field(
+        None,
+        ge=0,
+        description="The maximum allowed length, in characters, of a string value. "
+        "Only valid for the `string` type.",
+    )
+    min_length: int | None = Field(
+        0,
+        ge=0,
+        description="The minimum allowed length, in characters, of a string value. "
+        "Only valid for the `string` type.",
+    )
 
     _json_validator: builtins.type[Validator] = PrivateAttr()
 

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -31,20 +31,13 @@ contributions:
       title: Create widget from my function
       python_name: my_plugin:make_widget_from_function
   configuration:
-    - title: Reader Settings
+    - title: My Plugin
       properties:
         my_plugin.reader.lazy:
           type: boolean
           default: false
           title: Load lazily
           description: Whether to load images lazily with dask
-    - title: Command Settings
-      properties:
-        my_plugin.command.some_setting:
-          type: string
-          default: "default value"
-          title: Some Setting
-          description: A setting for a command
   readers:
     - command: my-plugin.some_reader
       filename_patterns: ["*.fzy", "*.fzzy"]

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -31,13 +31,20 @@ contributions:
       title: Create widget from my function
       python_name: my_plugin:make_widget_from_function
   configuration:
-    - title: My Plugin
+    - title: Reader Settings
       properties:
         my_plugin.reader.lazy:
           type: boolean
           default: false
           title: Load lazily
           description: Whether to load images lazily with dask
+    - title: Command Settings
+      properties:
+        my_plugin.command.some_setting:
+          type: string
+          default: "default value"
+          title: Some Setting
+          description: A setting for a command
   readers:
     - command: my-plugin.some_reader
       filename_patterns: ["*.fzy", "*.fzzy"]


### PR DESCRIPTION
Closes #494 

This PR adds a description to all fields in the class they are declared. We no longer re-define `type`, `default`, `description` and `enum` in `ConfigurationProperty`, as they are already defined (and now documented) in `ConfigurationJsonSchema`. 

After this PR, `ConfigurationProperty` only defines **additional** fields that are **not** present in `ConfigurationJsonSchema` and **not** compatible with the JSON Schema spec.