### PR TITLE
Make title, type and default required fields for ConfigurationProperty

### DIFF
--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -100,18 +100,12 @@ class ConfigurationJsonSchema(BaseModel):
         description="Identifies the JSON Schema dialect this document conforms to. "
         "Applies to the schema itself, not to any particular instance type.",
     )
-    title: str | None = Field(
-        None,
+
+    # required fields for a configuration property
+    title: str = Field(
         description="The title of this configuration property. This will be displayed "
         "in the settings UI as the label for this property.",
     )
-    description: str | None = Field(
-        None,
-        description="Your `description` appears after the title and before the input "
-        "field, except for booleans, where the description is used as the label for "
-        "the checkbox",
-    )
-
     type: Annotated[JsonType, BeforeValidator(_to_json_type)] = Field(
         description="The type of this variable. Either a JSON Schema type name "
         "('boolean', 'integer', 'number', 'string') or a python type name "
@@ -119,7 +113,15 @@ class ConfigurationJsonSchema(BaseModel):
         "coerced to a JSON Schema type. For boolean entries, the description "
         "will be used as the label for the checkbox.",
     )
-    default: Any = Field(None, description="The default value for this property.")
+    default: Any = Field(description="The default value for this property.")
+
+    # optional fields for a configuration property
+    description: str | None = Field(
+        None,
+        description="Your `description` appears after the title and before the input "
+        "field, except for booleans, where the description is used as the label for "
+        "the checkbox",
+    )
     enum: conlist(Any, min_length=1) | None = Field(  # type: ignore
         None,
         description="A list of valid options for this field. If you provide this field,"

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -6,6 +6,7 @@ from npe2.manifest.contributions._json_schema import ValidationError
 PROPS = [
     {
         "plugin.heatmap.location": {
+            "title": "Heatmap location",
             "type": "string",
             "default": "right",
             "enum": ["left", "right"],
@@ -32,6 +33,7 @@ def test_config_contribution(props):
 def test_warn_on_refs_defs():
     with pytest.warns(UserWarning):
         ConfigurationProperty(
+            title="Test Property",
             type="string",
             default="baz",
             description="quux",
@@ -40,13 +42,17 @@ def test_warn_on_refs_defs():
 
 
 CASES = [
-    ({"type": "string", "minLength": 2}, "AB", "A"),
-    ({"type": "string", "maxLength": 3}, "AB", "ABCD"),
-    ({"type": "integer"}, 42, 3.123),
-    ({"type": float}, 42.45, "3.123"),
-    ({"type": int, "multipleOf": 10}, 30, 23),
-    ({"type": "number", "minimum": 100}, 100, 99),
-    ({"type": "number", "exclusiveMaximum": 100}, 99, 100),
+    ({"title": "T", "type": "string", "default": "AB", "minLength": 2}, "AB", "A"),
+    ({"title": "T", "type": "string", "default": "AB", "maxLength": 3}, "AB", "ABCD"),
+    ({"title": "T", "type": "integer", "default": 42}, 42, 3.123),
+    ({"title": "T", "type": float, "default": 42.45}, 42.45, "3.123"),
+    ({"title": "T", "type": int, "default": 30, "multipleOf": 10}, 30, 23),
+    ({"title": "T", "type": "number", "default": 100, "minimum": 100}, 100, 99),
+    (
+        {"title": "T", "type": "number", "default": 99, "exclusiveMaximum": 100},
+        99,
+        100,
+    ),
 ]
 
 


### PR DESCRIPTION
Previously, only `type` was required for `ConfigurationProperty`. We think, for use in napari settings, `title` and `default` should also be required.

This PR updates the `ConfigurationProperty` and tests accordingly.