### PR TITLE
Declare managed plugin worker environments

### DIFF
--- a/_docs/example_manifest.yaml
+++ b/_docs/example_manifest.yaml
@@ -1,9 +1,21 @@
 name: example-plugin
 display_name: Example Plugin
 contributions:
+  environments:
+    - id: example-plugin.segmentation
+      python: "3.12.*"
+      conda: [numpy, scikit-image]
+      channels: [conda-forge]
+      local_packages:
+        - path: worker-package
   commands:
     - id: example-plugin.hello_world
       title: Hello World
+    - id: example-plugin.segment_worker
+      title: Segment image in an isolated environment
+      python_name: example_worker.api:segment
+      environment: example-plugin.segmentation
+      accepts_worker_context: true
     - id: example-plugin.read_xyz
       title: Read ".xyz" files
       python_name: example_plugin.some_module:get_reader

--- a/_docs/example_manifest.yaml
+++ b/_docs/example_manifest.yaml
@@ -3,11 +3,13 @@ display_name: Example Plugin
 contributions:
   environments:
     - id: example-plugin.segmentation
+      display_name: Segmentation
+      provision: on_install
       python: "3.12.*"
       conda: [numpy, scikit-image]
       channels: [conda-forge]
       local_packages:
-        - path: worker-package
+        - path: worker
   commands:
     - id: example-plugin.hello_world
       title: Hello World

--- a/_docs/templates/_npe2_environments_guide.md.jinja
+++ b/_docs/templates/_npe2_environments_guide.md.jinja
@@ -5,8 +5,15 @@ Environment contributions let a plugin describe dependencies for qualified Pytho
 This prevents worker-only dependencies from changing napari's packages or conflicting with another plugin's worker dependencies.
 
 The plugin package still has a host portion installed with napari.
-Its manifest, widgets, command-launching code, and all code that uses napari or Qt APIs must remain lightweight and importable in the napari process.
-Dependencies unavailable in a default napari installation belong in an environment contribution, and code that imports them belongs behind an associated worker command.
+Its manifest, widgets, command-launching code, and all code that uses napari or Qt APIs run in the napari process.
+This host code may rely only on the standard library, the plugin's own modules, napari, and packages in napari's direct base requirements for the current platform.
+Every other runtime dependency belongs in an environment contribution, and code that imports it belongs behind an associated worker command.
+This rule applies regardless of a package's size, import time, or perceived compatibility.
+
+The main plugin distribution still declares each allowed package that host code imports directly.
+Every declared version constraint must accept the version installed with napari.
+For managed installation to enforce this contract, napari must inspect the selected wheel before changing the host environment, reject incompatible or additional requirements, and install an accepted wheel without dependency resolution.
+Installations performed directly with `pip`, Conda, or another external tool remain outside that guarantee.
 
 ```yaml
 contributions:
@@ -70,8 +77,8 @@ py-modules = ["example_worker"]
 ```
 
 Napari's environment backend installs this embedded project into the declared environment so the qualified `example_worker:segment` target is importable there.
-The outer plugin build must include the worker `pyproject.toml`, modules, and resources as package data.
-The plugin author publishes only the outer plugin distribution; the embedded worker project is not published or installed separately by the user.
+The main plugin build must include the worker `pyproject.toml`, modules, and resources as package data.
+The plugin author publishes only the main plugin distribution; the embedded worker project is not published or installed separately by the user.
 
 The `provision` policy controls when a napari-managed plugin installation should create an environment.
 `on_install` asks the plugin installation workflow to provision it immediately, while `on_demand` defers provisioning until the environment is prepared or a worker command first runs.

--- a/_docs/templates/_npe2_environments_guide.md.jinja
+++ b/_docs/templates/_npe2_environments_guide.md.jinja
@@ -12,6 +12,8 @@ Dependencies unavailable in a default napari installation belong in an environme
 contributions:
   environments:
     - id: example-plugin.segmentation
+      display_name: Segmentation
+      provision: on_install
       python: "3.12.*"
       conda:
         - numpy
@@ -21,8 +23,7 @@ contributions:
       channels:
         - conda-forge
       local_packages:
-        - path: worker-package
-          extras: [gpu]
+        - path: worker
       lockfile: locks/pixi.lock
   commands:
     - id: example-plugin.segment
@@ -33,13 +34,22 @@ contributions:
 ```
 
 Environment and command identifiers must be qualified by the plugin name, and a worker command can reference only an environment in the same manifest.
+Each environment also has a `display_name` for user interfaces that present its installation and runtime state.
 A worker command must provide `python_name`; dynamically registered or serialized callables are not worker targets.
 Widget, reader, writer, and sample-data contributions must use host commands because their existing call contracts require execution in the napari process.
 A widget can invoke a separate worker command through napari's managed worker API.
 
 `local_packages` and `lockfile` paths use `/` separators and are relative to `napari.yaml`.
 They cannot escape the manifest directory and must be included in the built plugin distribution.
-A local package is useful for keeping worker modules and their dependency metadata separate from the lightweight host package.
+Each local-package entry contains only a path to packaged worker source.
+Worker dependencies must be declared in the environment's `conda` and `pypi` lists rather than hidden in local-package extras or other package metadata.
+Napari owns the details of turning that source into an installable distribution for the managed environment.
+
+The `provision` policy controls when a napari-managed plugin installation should create an environment.
+`on_install` asks the plugin installation workflow to provision it immediately, while `on_demand` defers provisioning until the environment is prepared or a worker command first runs.
+The default is `on_demand`.
+This declaration does not make plugin discovery or installation with external tools such as `pip` and `conda` perform provisioning, and provisioning does not start workers.
+Napari starts managed workers lazily when a command needs them.
 
 If `accepts_worker_context` is true, napari passes the reserved keyword-only `napari_context` argument.
 Worker code can use this context for progress reporting and cooperative cancellation without importing napari or the environment backend.

--- a/_docs/templates/_npe2_environments_guide.md.jinja
+++ b/_docs/templates/_npe2_environments_guide.md.jinja
@@ -28,7 +28,7 @@ contributions:
   commands:
     - id: example-plugin.segment
       title: Segment image
-      python_name: example_worker.api:segment
+      python_name: example_worker:segment
       environment: example-plugin.segmentation
       accepts_worker_context: true
 ```
@@ -41,9 +41,37 @@ A widget can invoke a separate worker command through napari's managed worker AP
 
 `local_packages` and `lockfile` paths use `/` separators and are relative to `napari.yaml`.
 They cannot escape the manifest directory and must be included in the built plugin distribution.
-Each local-package entry contains only a path to packaged worker source.
-Worker dependencies must be declared in the environment's `conda` and `pypi` lists rather than hidden in local-package extras or other package metadata.
-Napari owns the details of turning that source into an installable distribution for the managed environment.
+Each local-package path must name an embedded Python project containing a `pyproject.toml`.
+The project metadata must provide a static `[project].name` and must not declare static or dynamic dependencies.
+Worker dependencies belong only in the environment's `conda` and `pypi` lists so the manifest remains the authoritative recipe napari can display, fingerprint, provision, and rebuild.
+
+A minimal flat worker project requires only two files:
+
+```text
+src/example_plugin/
+├── napari.yaml
+└── worker/
+    ├── pyproject.toml
+    └── example_worker.py
+```
+
+```toml
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "example-plugin-worker"
+version = "1.0.0"
+dependencies = []
+
+[tool.setuptools]
+py-modules = ["example_worker"]
+```
+
+Napari's environment backend installs this embedded project into the declared environment so the qualified `example_worker:segment` target is importable there.
+The outer plugin build must include the worker `pyproject.toml`, modules, and resources as package data.
+The plugin author publishes only the outer plugin distribution; the embedded worker project is not published or installed separately by the user.
 
 The `provision` policy controls when a napari-managed plugin installation should create an environment.
 `on_install` asks the plugin installation workflow to provision it immediately, while `on_demand` defers provisioning until the environment is prepared or a worker command first runs.

--- a/_docs/templates/_npe2_environments_guide.md.jinja
+++ b/_docs/templates/_npe2_environments_guide.md.jinja
@@ -1,0 +1,56 @@
+(environments-contribution-guide)=
+## Isolated worker environments
+
+Environment contributions let a plugin describe dependencies for qualified Python worker commands that napari executes outside the environment containing napari.
+This prevents worker-only dependencies from changing napari's packages or conflicting with another plugin's worker dependencies.
+
+The plugin package still has a host portion installed with napari.
+Its manifest, widgets, command-launching code, and all code that uses napari or Qt APIs must remain lightweight and importable in the napari process.
+Dependencies unavailable in a default napari installation belong in an environment contribution, and code that imports them belongs behind an associated worker command.
+
+```yaml
+contributions:
+  environments:
+    - id: example-plugin.segmentation
+      python: "3.12.*"
+      conda:
+        - numpy
+        - scikit-image
+      pypi:
+        - example-segmentation-framework>=2
+      channels:
+        - conda-forge
+      local_packages:
+        - path: worker-package
+          extras: [gpu]
+      lockfile: locks/pixi.lock
+  commands:
+    - id: example-plugin.segment
+      title: Segment image
+      python_name: example_worker.api:segment
+      environment: example-plugin.segmentation
+      accepts_worker_context: true
+```
+
+Environment and command identifiers must be qualified by the plugin name, and a worker command can reference only an environment in the same manifest.
+A worker command must provide `python_name`; dynamically registered or serialized callables are not worker targets.
+Widget, reader, writer, and sample-data contributions must use host commands because their existing call contracts require execution in the napari process.
+A widget can invoke a separate worker command through napari's managed worker API.
+
+`local_packages` and `lockfile` paths use `/` separators and are relative to `napari.yaml`.
+They cannot escape the manifest directory and must be included in the built plugin distribution.
+A local package is useful for keeping worker modules and their dependency metadata separate from the lightweight host package.
+
+If `accepts_worker_context` is true, napari passes the reserved keyword-only `napari_context` argument.
+Worker code can use this context for progress reporting and cooperative cancellation without importing napari or the environment backend.
+The remaining arguments and return value must use the values supported by napari's managed worker API, including ordinary NumPy arrays.
+
+Provisioned environments are persistent and reused until their declared recipe changes.
+An optional lockfile makes dependency resolution reproducible.
+Plugins migrating existing commands should opt in individually and keep the old host behavior until their packaging has been split; manifests without environment declarations remain fully compatible.
+
+```{warning}
+Managed environments provide dependency isolation, not a security sandbox.
+Worker code is plugin code and may retain access to the user's files, network, credentials, processes, and hardware.
+Users should install only plugins they trust.
+```

--- a/src/npe2/_command_registry.py
+++ b/src/npe2/_command_registry.py
@@ -113,7 +113,7 @@ class CommandRegistry:
         """Register all commands in a manifest"""
         if mf.contributions and mf.contributions.commands:
             for cmd in mf.contributions.commands:
-                if cmd.python_name and cmd.id not in self:
+                if cmd.python_name and cmd.environment is None and cmd.id not in self:
                     self.register(cmd.id, cmd.python_name)
 
     def unregister_manifest(self, mf: PluginManifest) -> None:

--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -28,6 +28,16 @@ def command_id(id: str) -> str:
     return id
 
 
+def environment_id(id: str) -> str:
+    if id and not COMMAND_ID_PATTERN.match(id):
+        raise ValueError(
+            f"{id!r} is not a valid environment id. It must begin with the package "
+            "name followed by a period, then may contain only alphanumeric "
+            "characters and underscores."
+        )
+    return id
+
+
 def package_name(name: str) -> str:
     """Assert that `name` is a valid package name in accordance with PEP-0508."""
     if name and not PACKAGE_NAME_PATTERN.match(name):

--- a/src/npe2/manifest/contributions/__init__.py
+++ b/src/npe2/manifest/contributions/__init__.py
@@ -1,6 +1,7 @@
 from ._commands import CommandContribution
 from ._configuration import ConfigurationContribution, ConfigurationProperty
 from ._contributions import ContributionPoints
+from ._environments import EnvironmentContribution, LocalPackageRequirement
 from ._menus import MenuCommand, MenuItem, Submenu
 from ._readers import ReaderContribution
 from ._sample_data import SampleDataContribution, SampleDataGenerator, SampleDataURI
@@ -14,8 +15,10 @@ __all__ = [
     "ConfigurationContribution",
     "ConfigurationProperty",
     "ContributionPoints",
+    "EnvironmentContribution",
     "LayerType",
     "LayerTypeConstraint",
+    "LocalPackageRequirement",
     "MenuCommand",
     "MenuItem",
     "ReaderContribution",

--- a/src/npe2/manifest/contributions/__init__.py
+++ b/src/npe2/manifest/contributions/__init__.py
@@ -1,7 +1,11 @@
 from ._commands import CommandContribution
 from ._configuration import ConfigurationContribution, ConfigurationProperty
 from ._contributions import ContributionPoints
-from ._environments import EnvironmentContribution, LocalPackageRequirement
+from ._environments import (
+    EnvironmentContribution,
+    EnvironmentProvision,
+    LocalPackageRequirement,
+)
 from ._menus import MenuCommand, MenuItem, Submenu
 from ._readers import ReaderContribution
 from ._sample_data import SampleDataContribution, SampleDataGenerator, SampleDataURI
@@ -16,6 +20,7 @@ __all__ = [
     "ConfigurationProperty",
     "ContributionPoints",
     "EnvironmentContribution",
+    "EnvironmentProvision",
     "LayerType",
     "LayerTypeConstraint",
     "LocalPackageRequirement",

--- a/src/npe2/manifest/contributions/_commands.py
+++ b/src/npe2/manifest/contributions/_commands.py
@@ -60,6 +60,21 @@ class CommandContribution(BaseModel):
         "`{obj.__module__}:{obj.__qualname__}` "
         "(e.g. `my_package.a_module:some_function`)",
     )
+    environment: Annotated[str, AfterValidator(_validators.environment_id)] | None = (
+        Field(
+            None,
+            description="Identifier of an isolated environment declared by this "
+            "plugin. "
+            "Commands associated with an environment execute as managed workers rather "
+            "than in the napari process.",
+        )
+    )
+    accepts_worker_context: bool = Field(
+        False,
+        description="Whether napari should inject a reserved keyword-only "
+        "`napari_context` argument for progress reporting and cooperative "
+        "cancellation. This is valid only for isolated worker commands.",
+    )
 
     short_title: str | None = Field(
         None,

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ._commands import CommandContribution
 from ._configuration import ConfigurationContribution
+from ._environments import EnvironmentContribution
 from ._keybindings import KeyBindingContribution
 from ._menus import MenuItem
 from ._readers import ReaderContribution
@@ -14,6 +15,7 @@ from ._writers import WriterContribution
 __all__ = [
     "CommandContribution",
     "ContributionPoints",
+    "EnvironmentContribution",
     "KeyBindingContribution",
     "MenuItem",
     "ReaderContribution",
@@ -29,6 +31,7 @@ __all__ = [
 
 class ContributionPoints(BaseModel):
     commands: list[CommandContribution] | None = None
+    environments: list[EnvironmentContribution] | None = None
     readers: list[ReaderContribution] | None = None
     writers: list[WriterContribution] | None = None
     widgets: list[WidgetContribution] | None = None

--- a/src/npe2/manifest/contributions/_environments.py
+++ b/src/npe2/manifest/contributions/_environments.py
@@ -51,16 +51,17 @@ def _reject_duplicate_requirements(values: list[str]) -> list[str]:
 
 
 class LocalPackageRequirement(BaseModel):
-    """A Python package shipped alongside the plugin manifest.
+    """Embedded Python worker source shipped alongside the plugin manifest.
 
-    Local packages are installed only in the declared isolated environment. Paths are
-    resolved relative to the manifest file by the environment manager.
+    Napari makes the source importable only in the declared isolated environment.
+    Paths are resolved relative to the manifest file by the environment manager.
+    Dependencies belong in the environment recipe rather than the embedded source.
     """
 
     path: ManifestRelativePath = Field(
         ...,
-        description="Path to the package, relative to the plugin manifest. The package "
-        "must be included in the plugin distribution.",
+        description="Path to embedded worker source, relative to the plugin manifest. "
+        "The source must be included in the plugin distribution.",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -112,8 +113,9 @@ class EnvironmentContribution(BaseModel):
     )
     local_packages: list[LocalPackageRequirement] = Field(
         default_factory=list,
-        description="Python packages shipped alongside the manifest and installed only "
-        "in this environment.",
+        description="Embedded worker sources shipped alongside the manifest and made "
+        "importable only in this environment. Their dependencies must be declared by "
+        "this environment.",
     )
     lockfile: ManifestRelativePath | None = Field(
         None,

--- a/src/npe2/manifest/contributions/_environments.py
+++ b/src/npe2/manifest/contributions/_environments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from enum import StrEnum
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Annotated
 
@@ -61,29 +62,15 @@ class LocalPackageRequirement(BaseModel):
         description="Path to the package, relative to the plugin manifest. The package "
         "must be included in the plugin distribution.",
     )
-    editable: bool = Field(
-        False,
-        description="Whether to install the local package in editable mode.",
-    )
-    extras: list[str] = Field(
-        default_factory=list,
-        description="Optional Python distribution extras to install.",
-    )
 
     model_config = ConfigDict(extra="forbid")
 
-    @field_validator("extras")
-    @classmethod
-    def _validate_extras(cls, values: list[str]) -> list[str]:
-        extras: list[str] = []
-        for value in values:
-            if not re.fullmatch(r"[A-Za-z0-9]+(?:[-_.][A-Za-z0-9]+)*", value):
-                raise ValueError(f"{value!r} is not a valid Python distribution extra")
-            normalized = re.sub(r"[-_.]+", "-", value).lower()
-            if normalized in {re.sub(r"[-_.]+", "-", item).lower() for item in extras}:
-                raise ValueError(f"Duplicate local package extra {value!r}")
-            extras.append(value)
-        return extras
+
+class EnvironmentProvision(StrEnum):
+    """When napari should provision a managed plugin environment."""
+
+    ON_INSTALL = "on_install"
+    ON_DEMAND = "on_demand"
 
 
 class EnvironmentContribution(BaseModel):
@@ -97,6 +84,15 @@ class EnvironmentContribution(BaseModel):
     id: Annotated[str, AfterValidator(_validators.environment_id)] = Field(
         ...,
         description="Plugin-qualified identifier for this environment.",
+    )
+    display_name: Annotated[str, AfterValidator(_validators.display_name)] = Field(
+        ...,
+        description="User-facing name for this environment.",
+    )
+    provision: EnvironmentProvision = Field(
+        EnvironmentProvision.ON_DEMAND,
+        description="When a napari-managed plugin installation should provision this "
+        "environment. This does not start worker processes.",
     )
     python: str = Field(
         ...,

--- a/src/npe2/manifest/contributions/_environments.py
+++ b/src/npe2/manifest/contributions/_environments.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
+
+from npe2.manifest import _validators
+
+
+def _manifest_relative_path(value: str) -> str:
+    value = value.strip()
+    windows_path = PureWindowsPath(value)
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or "\0" in value
+        or path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or any(part in {"", ".", ".."} for part in value.split("/"))
+    ):
+        raise ValueError(
+            "must be a safe path relative to the plugin manifest, using '/' separators"
+        )
+    return value
+
+
+ManifestRelativePath = Annotated[str, AfterValidator(_manifest_relative_path)]
+
+
+def _requirement_name(value: str) -> str | None:
+    match = re.match(r"([A-Za-z0-9][A-Za-z0-9_.-]*)", value)
+    if match is None:
+        return None
+    return re.sub(r"[-_.]+", "-", match.group(1)).lower()
+
+
+def _reject_duplicate_requirements(values: list[str]) -> list[str]:
+    names: set[str] = set()
+    for value in values:
+        name = _requirement_name(value)
+        if name is not None and name in names:
+            raise ValueError(f"Duplicate dependency declaration for {name!r}")
+        if name is not None:
+            names.add(name)
+    return values
+
+
+class LocalPackageRequirement(BaseModel):
+    """A Python package shipped alongside the plugin manifest.
+
+    Local packages are installed only in the declared isolated environment. Paths are
+    resolved relative to the manifest file by the environment manager.
+    """
+
+    path: ManifestRelativePath = Field(
+        ...,
+        description="Path to the package, relative to the plugin manifest. The package "
+        "must be included in the plugin distribution.",
+    )
+    editable: bool = Field(
+        False,
+        description="Whether to install the local package in editable mode.",
+    )
+    extras: list[str] = Field(
+        default_factory=list,
+        description="Optional Python distribution extras to install.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("extras")
+    @classmethod
+    def _validate_extras(cls, values: list[str]) -> list[str]:
+        extras: list[str] = []
+        for value in values:
+            if not re.fullmatch(r"[A-Za-z0-9]+(?:[-_.][A-Za-z0-9]+)*", value):
+                raise ValueError(f"{value!r} is not a valid Python distribution extra")
+            normalized = re.sub(r"[-_.]+", "-", value).lower()
+            if normalized in {re.sub(r"[-_.]+", "-", item).lower() for item in extras}:
+                raise ValueError(f"Duplicate local package extra {value!r}")
+            extras.append(value)
+        return extras
+
+
+class EnvironmentContribution(BaseModel):
+    """Declare a reusable isolated environment for plugin worker commands.
+
+    The host plugin remains installed with napari. Dependencies declared here are
+    provisioned separately by napari and are available only to worker commands
+    associated with this environment.
+    """
+
+    id: Annotated[str, AfterValidator(_validators.environment_id)] = Field(
+        ...,
+        description="Plugin-qualified identifier for this environment.",
+    )
+    python: str = Field(
+        ...,
+        description="Python version constraint for the isolated environment.",
+    )
+    conda: list[str] = Field(
+        default_factory=list,
+        description="Conda dependency specifications for the isolated environment.",
+    )
+    pypi: list[str] = Field(
+        default_factory=list,
+        description="PEP 508 Python package requirements for the isolated environment.",
+    )
+    channels: list[str] = Field(
+        default_factory=lambda: ["conda-forge"],
+        description="Ordered Conda channels used to resolve the environment.",
+    )
+    local_packages: list[LocalPackageRequirement] = Field(
+        default_factory=list,
+        description="Python packages shipped alongside the manifest and installed only "
+        "in this environment.",
+    )
+    lockfile: ManifestRelativePath | None = Field(
+        None,
+        description="Optional lockfile path, relative to the plugin manifest.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("python")
+    @classmethod
+    def _validate_python(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Python constraint cannot be empty")
+        return value
+
+    @field_validator("conda", "pypi", "channels")
+    @classmethod
+    def _validate_string_list(cls, values: list[str]) -> list[str]:
+        result: list[str] = []
+        for value in values:
+            value = value.strip()
+            if not value:
+                raise ValueError("Dependency and channel entries cannot be empty")
+            if value in result:
+                raise ValueError(f"Duplicate entry {value!r}")
+            result.append(value)
+        return result
+
+    @field_validator("conda", "pypi")
+    @classmethod
+    def _unique_dependencies(cls, values: list[str]) -> list[str]:
+        return _reject_duplicate_requirements(values)
+
+    @field_validator("channels")
+    @classmethod
+    def _require_channel(cls, values: list[str]) -> list[str]:
+        if not values:
+            raise ValueError("At least one Conda channel is required")
+        return values

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -327,7 +327,7 @@ class PluginManifest(ImportExportModel):
             for contribution_name in ("widgets", "readers", "writers", "sample_data"):
                 for contribution in getattr(contributions, contribution_name) or []:
                     command_id = getattr(contribution, "command", None)
-                    if command_id in worker_commands:
+                    if isinstance(command_id, str) and command_id in worker_commands:
                         incompatible_references.append((contribution_name, command_id))
             if incompatible_references:
                 details = ", ".join(

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -26,7 +26,7 @@ from npe2.types import PythonName
 from . import _validators
 from ._bases import ImportExportModel
 from ._package_metadata import PackageMetadata
-from .contributions import ContributionPoints
+from .contributions import CommandContribution, ContributionPoints
 from .contributions._icon import Icon
 from .utils import Executable, Version
 
@@ -35,7 +35,7 @@ __all__ = ("Category",)
 logger = getLogger(__name__)
 
 
-SCHEMA_VERSION = "0.2.1"
+SCHEMA_VERSION = "0.3.0"
 ENTRY_POINT = "napari.manifest"
 NPE1_ENTRY_POINT = "napari.plugin"
 
@@ -272,6 +272,7 @@ class PluginManifest(ImportExportModel):
             )
 
         invalid_commands: list[str] = []
+        invalid_environments: list[str] = []
         if values.get("contributions") is not None:
             contributions = values["contributions"]
             if isinstance(contributions, dict):
@@ -281,12 +282,74 @@ class PluginManifest(ImportExportModel):
                 for command in contributions.commands or []
                 if not command.id.startswith(f"{mf_name}.")
             )
+            invalid_environments.extend(
+                environment.id
+                for environment in contributions.environments or []
+                if not environment.id.startswith(f"{mf_name}.")
+            )
+
+            environments = {
+                environment.id: environment
+                for environment in contributions.environments or []
+            }
+            if len(environments) != len(contributions.environments or []):
+                raise ValueError("Environment identifiers must be unique")
+
+            worker_commands = {
+                command.id: command
+                for command in contributions.commands or []
+                if command.environment is not None
+            }
+            for command in contributions.commands or []:
+                if command.accepts_worker_context and command.environment is None:
+                    raise ValueError(
+                        f"Command {command.id!r} accepts a worker context but does not "
+                        "declare an isolated environment"
+                    )
+                if command.environment is None:
+                    continue
+                if command.python_name is None:
+                    raise ValueError(
+                        f"Worker command {command.id!r} must declare a python_name"
+                    )
+                if not command.environment.startswith(f"{mf_name}."):
+                    raise ValueError(
+                        f"Worker command {command.id!r} must reference an environment "
+                        f"owned by plugin {mf_name!r}"
+                    )
+                if command.environment not in environments:
+                    raise ValueError(
+                        f"Worker command {command.id!r} references undeclared "
+                        f"environment {command.environment!r}"
+                    )
+
+            incompatible_references: list[tuple[str, str]] = []
+            for contribution_name in ("widgets", "readers", "writers", "sample_data"):
+                for contribution in getattr(contributions, contribution_name) or []:
+                    command_id = getattr(contribution, "command", None)
+                    if command_id in worker_commands:
+                        incompatible_references.append((contribution_name, command_id))
+            if incompatible_references:
+                details = ", ".join(
+                    f"{name}: {command_id}"
+                    for name, command_id in incompatible_references
+                )
+                raise ValueError(
+                    "Isolated worker commands cannot implement widgets, readers, "
+                    f"writers, or sample data contributions ({details})"
+                )
 
         if invalid_commands:
             raise ValueError(
                 "Commands identifiers must start with the current package name "
                 f"followed by a dot: '{mf_name}'. The following commands do not: "
                 f"{invalid_commands}"
+            )
+        if invalid_environments:
+            raise ValueError(
+                "Environment identifiers must start with the current package name "
+                f"followed by a dot: '{mf_name}'. The following environments do not: "
+                f"{invalid_environments}"
             )
 
         if not values.get("display_name"):
@@ -480,6 +543,12 @@ class PluginManifest(ImportExportModel):
         def check_pynames(m: BaseModel, loc=()):
             for name, value in m:
                 if not value:
+                    continue
+                if (
+                    isinstance(m, CommandContribution)
+                    and m.environment is not None
+                    and name == "python_name"
+                ):
                     continue
                 if isinstance(value, BaseModel):
                     return check_pynames(value, (*loc, name))

--- a/tests/test_environment_contributions.py
+++ b/tests/test_environment_contributions.py
@@ -345,6 +345,7 @@ def test_json_schema_contains_environment_contract() -> None:
     environment_fields = schema["$defs"]["EnvironmentContribution"]["properties"]
     local_package_fields = schema["$defs"]["LocalPackageRequirement"]["properties"]
 
+    assert schema["properties"]["schema_version"]["default"] == "0.3.0"
     assert "environments" in contribution_fields
     assert environment_fields["provision"]["default"] == "on_demand"
     assert "display_name" in schema["$defs"]["EnvironmentContribution"]["required"]

--- a/tests/test_environment_contributions.py
+++ b/tests/test_environment_contributions.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from npe2 import PluginManifest
+from npe2._command_registry import CommandRegistry
+from npe2.cli import validate
+from npe2.manifest.contributions import (
+    EnvironmentContribution,
+    LocalPackageRequirement,
+)
+
+
+def _worker_manifest(**contributions) -> PluginManifest:
+    data = {
+        "environments": [{"id": "example-plugin.worker", "python": "3.12.*"}],
+        "commands": [
+            {
+                "id": "example-plugin.segment",
+                "title": "Segment",
+                "python_name": "worker_package.api:segment",
+                "environment": "example-plugin.worker",
+            }
+        ],
+    }
+    data.update(contributions)
+    return PluginManifest(name="example-plugin", contributions=data)
+
+
+def test_environment_recipe_round_trip(tmp_path: Path) -> None:
+    manifest_file = tmp_path / "napari.yaml"
+    manifest_file.write_text(
+        """
+name: example-plugin
+contributions:
+  environments:
+    - id: example-plugin.worker
+      python: "3.12.*"
+      conda: [numpy=1.26, scikit-image]
+      pypi: [segment-anything>=1]
+      channels: [conda-forge, pytorch]
+      local_packages:
+        - path: worker-package
+          editable: true
+          extras: [gpu]
+      lockfile: locks/pixi.lock
+  commands:
+    - id: example-plugin.segment
+      title: Segment
+      python_name: worker_package.api:segment
+      environment: example-plugin.worker
+      accepts_worker_context: true
+""",
+        encoding="utf-8",
+    )
+
+    manifest = PluginManifest.from_file(manifest_file)
+    [environment] = manifest.contributions.environments or []
+    [command] = manifest.contributions.commands or []
+
+    assert environment == EnvironmentContribution(
+        id="example-plugin.worker",
+        python="3.12.*",
+        conda=["numpy=1.26", "scikit-image"],
+        pypi=["segment-anything>=1"],
+        channels=["conda-forge", "pytorch"],
+        local_packages=[
+            LocalPackageRequirement(
+                path="worker-package", editable=True, extras=["gpu"]
+            )
+        ],
+        lockfile="locks/pixi.lock",
+    )
+    assert command.environment == environment.id
+    assert command.accepts_worker_context
+    assert (
+        PluginManifest(**manifest.model_dump(exclude={"package_metadata"})).model_dump()
+        == manifest.model_dump()
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("python", ""),
+        ("conda", ["numpy>=1", "NumPy<2"]),
+        ("pypi", ["my-package>=1", "my_package<2"]),
+        ("channels", []),
+        ("channels", ["conda-forge", "conda-forge"]),
+        ("lockfile", "/tmp/pixi.lock"),
+        ("lockfile", "../pixi.lock"),
+        ("lockfile", r"locks\pixi.lock"),
+    ],
+)
+def test_invalid_environment_recipe(field: str, value: object) -> None:
+    recipe: dict[str, object] = {
+        "id": "example-plugin.worker",
+        "python": "3.12",
+    }
+    recipe[field] = value
+    with pytest.raises(ValidationError):
+        EnvironmentContribution(**recipe)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        ".",
+        "..",
+        "../worker",
+        "worker/../other",
+        "worker//package",
+        "/worker",
+        r"worker\package",
+    ],
+)
+def test_local_package_path_must_be_manifest_relative(path: str) -> None:
+    with pytest.raises(ValidationError, match="safe path relative"):
+        LocalPackageRequirement(path=path)
+
+
+def test_environment_ids_are_unique_and_plugin_qualified() -> None:
+    duplicate = [
+        {"id": "example-plugin.worker", "python": "3.12"},
+        {"id": "example-plugin.worker", "python": "3.11"},
+    ]
+    with pytest.raises(ValidationError, match="identifiers must be unique"):
+        _worker_manifest(environments=duplicate)
+
+    with pytest.raises(ValidationError, match="current package name"):
+        _worker_manifest(
+            environments=[{"id": "another-plugin.worker", "python": "3.12"}],
+            commands=[],
+        )
+
+
+def test_worker_command_requires_target_and_local_environment() -> None:
+    with pytest.raises(ValidationError, match="must declare a python_name"):
+        _worker_manifest(
+            commands=[
+                {
+                    "id": "example-plugin.segment",
+                    "title": "Segment",
+                    "environment": "example-plugin.worker",
+                }
+            ]
+        )
+
+    with pytest.raises(ValidationError, match="undeclared environment"):
+        _worker_manifest(
+            commands=[
+                {
+                    "id": "example-plugin.segment",
+                    "title": "Segment",
+                    "python_name": "worker_package.api:segment",
+                    "environment": "example-plugin.missing",
+                }
+            ]
+        )
+
+    with pytest.raises(ValidationError, match="owned by plugin"):
+        _worker_manifest(
+            commands=[
+                {
+                    "id": "example-plugin.segment",
+                    "title": "Segment",
+                    "python_name": "worker_package.api:segment",
+                    "environment": "another-plugin.worker",
+                }
+            ]
+        )
+
+
+def test_worker_context_is_only_valid_for_worker_commands() -> None:
+    with pytest.raises(ValidationError, match="accepts a worker context"):
+        _worker_manifest(
+            commands=[
+                {
+                    "id": "example-plugin.host",
+                    "title": "Host command",
+                    "python_name": "host_package.api:command",
+                    "accepts_worker_context": True,
+                }
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("contribution", "value"),
+    [
+        (
+            "widgets",
+            [{"command": "example-plugin.segment", "display_name": "Segment"}],
+        ),
+        (
+            "readers",
+            [
+                {
+                    "command": "example-plugin.segment",
+                    "filename_patterns": ["*.tif"],
+                }
+            ],
+        ),
+        (
+            "writers",
+            [{"command": "example-plugin.segment", "layer_types": ["image"]}],
+        ),
+        (
+            "sample_data",
+            [
+                {
+                    "command": "example-plugin.segment",
+                    "key": "sample",
+                    "display_name": "Sample",
+                }
+            ],
+        ),
+    ],
+)
+def test_worker_commands_cannot_implement_host_contributions(
+    contribution: str, value: object
+) -> None:
+    with pytest.raises(ValidationError, match="cannot implement"):
+        _worker_manifest(**{contribution: value})
+
+
+def test_validate_imports_skips_worker_targets() -> None:
+    manifest = _worker_manifest(
+        commands=[
+            {
+                "id": "example-plugin.segment",
+                "title": "Segment",
+                "python_name": "package_not_installed_in_host.api:segment",
+                "environment": "example-plugin.worker",
+            }
+        ]
+    )
+    manifest.validate_imports()
+
+    manifest = PluginManifest(
+        name="example-plugin",
+        contributions={
+            "commands": [
+                {
+                    "id": "example-plugin.host",
+                    "title": "Host command",
+                    "python_name": "package_not_installed_in_host.api:command",
+                }
+            ]
+        },
+    )
+    with pytest.raises(ValidationError, match="package_not_installed_in_host"):
+        manifest.validate_imports()
+
+
+def test_validate_cli_skips_worker_target_import(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest_file = tmp_path / "napari.yaml"
+    manifest_file.write_text(_worker_manifest().yaml(), encoding="utf-8")
+
+    validate(str(manifest_file), imports=True, debug=False)
+
+    assert "valid!" in capsys.readouterr().out
+
+
+def test_command_registry_does_not_import_worker_target() -> None:
+    manifest = _worker_manifest()
+    registry = CommandRegistry()
+
+    registry.register_manifest(manifest)
+
+    assert "example-plugin.segment" not in registry
+
+
+def test_json_schema_contains_environment_contract() -> None:
+    schema = PluginManifest.model_json_schema()
+    contribution_fields = schema["$defs"]["ContributionPoints"]["properties"]
+    command_fields = schema["$defs"]["CommandContribution"]["properties"]
+
+    assert "environments" in contribution_fields
+    assert "environment" in command_fields
+    assert "accepts_worker_context" in command_fields

--- a/tests/test_environment_contributions.py
+++ b/tests/test_environment_contributions.py
@@ -10,13 +10,20 @@ from npe2._command_registry import CommandRegistry
 from npe2.cli import validate
 from npe2.manifest.contributions import (
     EnvironmentContribution,
+    EnvironmentProvision,
     LocalPackageRequirement,
 )
 
 
 def _worker_manifest(**contributions) -> PluginManifest:
     data = {
-        "environments": [{"id": "example-plugin.worker", "python": "3.12.*"}],
+        "environments": [
+            {
+                "id": "example-plugin.worker",
+                "display_name": "Worker",
+                "python": "3.12.*",
+            }
+        ],
         "commands": [
             {
                 "id": "example-plugin.segment",
@@ -38,14 +45,14 @@ name: example-plugin
 contributions:
   environments:
     - id: example-plugin.worker
+      display_name: Segmentation worker
+      provision: on_install
       python: "3.12.*"
       conda: [numpy=1.26, scikit-image]
       pypi: [segment-anything>=1]
       channels: [conda-forge, pytorch]
       local_packages:
         - path: worker-package
-          editable: true
-          extras: [gpu]
       lockfile: locks/pixi.lock
   commands:
     - id: example-plugin.segment
@@ -63,15 +70,13 @@ contributions:
 
     assert environment == EnvironmentContribution(
         id="example-plugin.worker",
+        display_name="Segmentation worker",
+        provision=EnvironmentProvision.ON_INSTALL,
         python="3.12.*",
         conda=["numpy=1.26", "scikit-image"],
         pypi=["segment-anything>=1"],
         channels=["conda-forge", "pytorch"],
-        local_packages=[
-            LocalPackageRequirement(
-                path="worker-package", editable=True, extras=["gpu"]
-            )
-        ],
+        local_packages=[LocalPackageRequirement(path="worker-package")],
         lockfile="locks/pixi.lock",
     )
     assert command.environment == environment.id
@@ -98,11 +103,53 @@ contributions:
 def test_invalid_environment_recipe(field: str, value: object) -> None:
     recipe: dict[str, object] = {
         "id": "example-plugin.worker",
+        "display_name": "Worker",
         "python": "3.12",
     }
     recipe[field] = value
     with pytest.raises(ValidationError):
         EnvironmentContribution(**recipe)
+
+
+def test_environment_provision_defaults_to_on_demand() -> None:
+    environment = EnvironmentContribution(
+        id="example-plugin.worker",
+        display_name="Worker",
+        python="3.12",
+    )
+
+    assert environment.provision is EnvironmentProvision.ON_DEMAND
+
+
+@pytest.mark.parametrize("display_name", [None, "", " worker"])
+def test_environment_requires_valid_display_name(
+    display_name: str | None,
+) -> None:
+    recipe = {
+        "id": "example-plugin.worker",
+        "python": "3.12",
+    }
+    if display_name is not None:
+        recipe["display_name"] = display_name
+
+    with pytest.raises(ValidationError, match="display_name"):
+        EnvironmentContribution(**recipe)
+
+
+def test_environment_rejects_invalid_provision_policy() -> None:
+    with pytest.raises(ValidationError, match=r"on_install|on_demand"):
+        EnvironmentContribution(
+            id="example-plugin.worker",
+            display_name="Worker",
+            provision="eager",
+            python="3.12",
+        )
+
+
+@pytest.mark.parametrize("field", ["editable", "extras"])
+def test_local_package_contains_only_a_path(field: str) -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        LocalPackageRequirement(path="worker-package", **{field: True})
 
 
 @pytest.mark.parametrize(
@@ -125,15 +172,29 @@ def test_local_package_path_must_be_manifest_relative(path: str) -> None:
 
 def test_environment_ids_are_unique_and_plugin_qualified() -> None:
     duplicate = [
-        {"id": "example-plugin.worker", "python": "3.12"},
-        {"id": "example-plugin.worker", "python": "3.11"},
+        {
+            "id": "example-plugin.worker",
+            "display_name": "First worker",
+            "python": "3.12",
+        },
+        {
+            "id": "example-plugin.worker",
+            "display_name": "Second worker",
+            "python": "3.11",
+        },
     ]
     with pytest.raises(ValidationError, match="identifiers must be unique"):
         _worker_manifest(environments=duplicate)
 
     with pytest.raises(ValidationError, match="current package name"):
         _worker_manifest(
-            environments=[{"id": "another-plugin.worker", "python": "3.12"}],
+            environments=[
+                {
+                    "id": "another-plugin.worker",
+                    "display_name": "Worker",
+                    "python": "3.12",
+                }
+            ],
             commands=[],
         )
 
@@ -281,7 +342,13 @@ def test_json_schema_contains_environment_contract() -> None:
     schema = PluginManifest.model_json_schema()
     contribution_fields = schema["$defs"]["ContributionPoints"]["properties"]
     command_fields = schema["$defs"]["CommandContribution"]["properties"]
+    environment_fields = schema["$defs"]["EnvironmentContribution"]["properties"]
+    local_package_fields = schema["$defs"]["LocalPackageRequirement"]["properties"]
 
     assert "environments" in contribution_fields
+    assert environment_fields["provision"]["default"] == "on_demand"
+    assert "display_name" in schema["$defs"]["EnvironmentContribution"]["required"]
+    assert {"display_name", "provision"} <= environment_fields.keys()
+    assert local_package_fields.keys() == {"path"}
     assert "environment" in command_fields
     assert "accepts_worker_context" in command_fields


### PR DESCRIPTION
# Declare managed plugin worker environments

## Summary

This PR adds the manifest vocabulary applications need to manage dependency-heavy plugin functions in isolated environments.

The coordinated objective is to guarantee that any set of conforming plugins installed through napari's managed flow can coexist in one napari installation without changing napari's dependency set or introducing plugin-to-plugin dependency conflicts.
Plugin code that uses napari or Qt remains ordinary host-process code.
Code requiring dependencies outside napari's runtime set is exposed as a qualified worker target and associated with a named managed environment.

## AI assistance disclosure

The code, tests, documentation, commits, and this PR description were fully generated with GPT-5.6 Sol at high reasoning effort, under my direction.
I validated the result and remain responsible for the contribution.
If this does not comply with the project's Code of Conduct, contribution policy, or maintainer expectations, I can withdraw the PR.

This is motivated by napari/napari#1001, napari/napari#2114, napari/napari#4800, and the plugin-management context in napari/napari#4952.
It does not claim to close those issues by itself.

## Manifest model

The schema adds:

- named environment contributions with a required display name;
- Python, Conda, PyPI, channel, embedded local-package, and optional Pixi lockfile requirements;
- `provision: on_install | on_demand`, defaulting to `on_demand`;
- a command-to-environment reference for qualified Python call targets; and
- validation of IDs, references, requirement syntax, paths, lockfiles, and duplicate declarations.

npe2 describes declarations only.
It does not choose a provisioning backend, expose transport details, or start workers.
The coordinated napari PR owns runtime lookup, preparation, progress, cancellation, failures, persistent reuse, worker lifecycle, and shutdown.

## Downstream usage

The schema is intended to support a complete plugin declaration such as:

```yaml
contributions:
  environments:
    - id: example-plugin.segmentation
      display_name: Segmentation
      provision: on_demand
      python: "3.12.*"
      pypi:
        - example-segmentation-framework==2.0
      channels:
        - conda-forge
      local_packages:
        - path: worker
  commands:
    - id: example-plugin.segment
      title: Segment image
      python_name: example_worker:segment
      environment: example-plugin.segmentation
      accepts_worker_context: true
```

Host-side widget code remains in napari and invokes the declared command through napari's API:

```python
from napari.plugins import execute_worker_command

task = execute_worker_command("example-plugin.segment", image)
task.add_progress_callback(update_progress_bar)
task.add_done_callback(add_result_layer)

# A Cancel button can call task.cancel().
```

The embedded target is imported only inside the managed environment and receives ordinary values and NumPy arrays:

```python
def segment(image, *, napari_context=None):
    from example_segmentation_framework import segment_image

    if napari_context is not None:
        napari_context.update("Segmenting image", current=0, maximum=1)
    return segment_image(image)
```

The plugin author writes no provisioning, subprocess, or transport code.
The companion [napari runtime draft PR #9347](https://github.com/napari/napari/pull/9347) implements the task API and environment lifecycle behind this declaration; the [WSegmenter integration branch](https://github.com/arthursw/napari-wsegmenter/tree/feature/plugin-environments) exercises the same pattern with Cellpose, StarDist, and SAM 2.

## Packaging contract

A plugin remains one normal distribution installed into napari.
That distribution may contain a small, independently buildable worker project, for example:

```text
src/napari_example/
├── napari.yaml
├── _widget.py
└── worker/
    ├── pyproject.toml
    └── napari_example_worker.py
```

The embedded project's metadata makes its qualified targets importable in a worker environment, but it must not declare runtime dependencies.
The manifest environment is the single dependency authority.
This avoids a second published distribution and avoids resolving the worker's heavy dependencies into the napari process.

The schema constrains embedded package references to safe relative paths inside the installed plugin distribution.
Worker environments isolate dependencies; they are not security sandboxes, and worker code has the user's permissions.

## Compatibility and dependency order

Existing manifests and commands remain valid.
Plugins opt into this model by adding environment contributions and associating selected commands with them.
Discovery keeps qualified targets lazy and does not import dependency-heavy worker modules.

This PR is independently mergeable and has no dependency on Wetlands or napari runtime code.
The coordinated napari runtime PR will require an npe2 release containing this schema.

Host-dependency policy enforcement is intentionally proposed as a second, stacked npe2 PR so schema review is not coupled to installer policy.

## Validation

- Full test suite: 301 passed, 8 skipped, 1 deselected
- Focused environment and schema tests
- Ruff check and format check
- Generated documentation templates and JSON-schema metaschema validation
- YAML/TOML and manifest validation
