### PR TITLE
Validate titles and keys of ConfigurationContribution

### DIFF
--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -1,6 +1,61 @@
+import re
+from collections.abc import Iterable
+
 from pydantic import BaseModel, Field, model_validator
 
 from ._json_schema import ConfigurationJsonSchema
+
+
+def normalize_title(title: str) -> str:
+    """Return a canonical snake_case key for a configuration title.
+
+    Configuration titles are free-form text (e.g. "Demo Configuration for
+    widget 1") but consumers (e.g. napari) use them to derive identifier-like
+    keys / field names.  Normalizing titles to a canonical key lets npe2
+    enforce that titles are unique within a plugin, and lets consumers reuse
+    the same normalization instead of implementing (possibly divergent) ones.
+
+    Examples
+    --------
+    >>> normalize_title('Demo Configuration for widget 1')
+    'demo_configuration_for_widget_1'
+    >>> normalize_title('main widget')
+    'main_widget'
+    """
+    # camelCase -> snake_case (e.g. someSetting -> some_Setting)
+    name = re.sub(r'(?<!^)(?=[A-Z])', '_', title)
+    # any run of non-alphanumeric characters is a separator
+    name = re.sub(r'[^0-9a-zA-Z]+', '_', name)
+    name = re.sub(r'_+', '_', name).strip('_').lower()
+    if not name:
+        name = 'settings'
+    if name[0].isdigit():
+        name = f'_{name}'
+    return name
+
+
+def _ensure_unique_normalized(items: Iterable[str], what: str) -> None:
+    """Raise if any two strings in ``items`` normalize to the same key.
+
+    Parameters
+    ----------
+    items : Iterable[str]
+        The free-form strings to check for collisions after
+        :func:`normalize_title`.
+    what : str
+        Human-readable noun phrase used in the error message, e.g.
+        "Configuration titles".
+    """
+    seen: dict[str, str] = {}
+    for original in items:
+        key = normalize_title(original)
+        if key in seen:
+            raise ValueError(
+                f"{what} {seen[key]!r} and {original!r} both normalize to "
+                f"{key!r}; duplicate {what.lower()} are not allowed (case, "
+                "whitespace, and punctuation are ignored)."
+            )
+        seen[key] = original
 
 
 class ConfigurationProperty(ConfigurationJsonSchema):
@@ -69,5 +124,12 @@ class ConfigurationContribution(BaseModel):
         "breaks. For example, if your key is 'gitMagic.blame.dateFormat', the "
         "generated title for the setting will look like 'Blame: Date Format'",
     )
+
+    @model_validator(mode="after")
+    def _validate_unique_property_keys(self):
+        """Property keys must be unique once normalized to snake_case."""
+        _ensure_unique_normalized(self.properties, "Configuration properties")
+        return self
+
     # order: int  # vscode uses this to sort multiple configurations
     # ... I think we can just use the order in which they are declared

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -23,14 +23,14 @@ def normalize_title(title: str) -> str:
     'main_widget'
     """
     # camelCase -> snake_case (e.g. someSetting -> some_Setting)
-    name = re.sub(r'(?<!^)(?=[A-Z])', '_', title)
+    name = re.sub(r"(?<!^)(?=[A-Z])", "_", title)
     # any run of non-alphanumeric characters is a separator
-    name = re.sub(r'[^0-9a-zA-Z]+', '_', name)
-    name = re.sub(r'_+', '_', name).strip('_').lower()
+    name = re.sub(r"[^0-9a-zA-Z]+", "_", name)
+    name = re.sub(r"_+", "_", name).strip("_").lower()
     if not name:
-        name = 'settings'
+        name = "settings"
     if name[0].isdigit():
-        name = f'_{name}'
+        name = f"_{name}"
     return name
 
 

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -1,7 +1,10 @@
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ._commands import CommandContribution
-from ._configuration import ConfigurationContribution
+from ._configuration import (
+    ConfigurationContribution,
+    _ensure_unique_normalized,
+)
 from ._keybindings import KeyBindingContribution
 from ._menus import MenuItem
 from ._readers import ReaderContribution
@@ -60,3 +63,12 @@ class ContributionPoints(BaseModel):
     @classmethod
     def _to_list(cls, v):
         return v if isinstance(v, list) else [v]
+
+    @model_validator(mode="after")
+    def _validate_unique_configuration_titles(self):
+        """Configuration titles must be unique once normalized to snake_case."""
+        _ensure_unique_normalized(
+            (conf.title for conf in self.configuration),
+            "Configuration titles",
+        )
+        return self

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -5,8 +5,8 @@ from npe2.manifest.contributions import (
     ConfigurationContribution,
     ConfigurationProperty,
     ContributionPoints,
-    normalize_title,
 )
+from npe2.manifest.contributions._configuration import normalize_title
 from npe2.manifest.contributions._json_schema import ValidationError
 
 PROPS = [

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -1,6 +1,12 @@
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
-from npe2.manifest.contributions import ConfigurationContribution, ConfigurationProperty
+from npe2.manifest.contributions import (
+    ConfigurationContribution,
+    ConfigurationProperty,
+    ContributionPoints,
+    normalize_title,
+)
 from npe2.manifest.contributions._json_schema import ValidationError
 
 PROPS = [
@@ -69,3 +75,59 @@ def test_config_validation(schema, valid, invalid):
     # check that we can convert json type to python type
     assert cfg.python_type.__module__ == "builtins"
     assert cfg.has_default is ("default" in schema)
+
+
+def test_normalize_title():
+    assert (
+        normalize_title("Demo Configuration for widget 1")
+        == "demo_configuration_for_widget_1"
+    )
+    assert normalize_title("main widget") == "main_widget"
+    assert normalize_title("someSetting") == "some_setting"
+
+
+def test_duplicate_configuration_titles_raise():
+    with pytest.raises(PydanticValidationError, match="both normalize to"):
+        ContributionPoints(
+            configuration=[
+                {
+                    "title": "Main Widget",
+                    "properties": {
+                        "p.a": {
+                            "title": "A",
+                            "type": "boolean",
+                            "default": False,
+                        },
+                    },
+                },
+                {
+                    "title": "main widget",
+                    "properties": {
+                        "p.b": {
+                            "title": "B",
+                            "type": "boolean",
+                            "default": False,
+                        },
+                    },
+                },
+            ]
+        )
+
+
+def test_duplicate_property_keys_raise():
+    with pytest.raises(PydanticValidationError, match="both normalize to"):
+        ConfigurationContribution(
+            title="My Widget",
+            properties={
+                "plugin.a.lazy": {
+                    "title": "Lazy",
+                    "type": "boolean",
+                    "default": False,
+                },
+                "plugin.a-lazy": {
+                    "title": "Lazy 2",
+                    "type": "boolean",
+                    "default": False,
+                },
+            },
+        )

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -77,13 +77,21 @@ def test_config_validation(schema, valid, invalid):
     assert cfg.has_default is ("default" in schema)
 
 
-def test_normalize_title():
-    assert (
-        normalize_title("Demo Configuration for widget 1")
-        == "demo_configuration_for_widget_1"
-    )
-    assert normalize_title("main widget") == "main_widget"
-    assert normalize_title("someSetting") == "some_setting"
+@pytest.mark.parametrize(
+    "title, expected",
+    [
+        ("Demo Configuration for widget 1", "demo_configuration_for_widget_1"),
+        ("main widget", "main_widget"),
+        ("someSetting", "some_setting"),
+        # no alphanumeric content at all -> fall back to a generic key
+        ("", "settings"),
+        ("!!!", "settings"),
+        # leading digit -> prefix underscore so the key is a valid identifier
+        ("123 hello", "_123_hello"),
+    ],
+)
+def test_normalize_title(title, expected):
+    assert normalize_title(title) == expected
 
 
 def test_duplicate_configuration_titles_raise():


### PR DESCRIPTION
# References and Relevant Issues

napari/napari#9308

# Description

Configuration contribution **titles** and **property keys** are free-form text, but napari derives field names from them (`Demo Configuration for widget 1` → `demo_configuration_for_widget_1`) in Pydantic models. When two names normalize to the same thing, the settings UI silently collides and overwrites

This PR makes npe2 reject those collisions at manifest validation time (`npe2 validate`, `PluginManifest.from_file`) with a clear error instead of failing or silently overwriting later downstream.

Perhaps right now, this is a bit of over-engineering, but we do often reply to manifest related issues that are due to sneaky typos, characters and other sorts of punctuation.