### PR TITLE
Make manifest.configuration a dictionary

### DIFF
--- a/src/npe2/manifest/_validators.py
+++ b/src/npe2/manifest/_validators.py
@@ -1,3 +1,4 @@
+import keyword
 import re
 
 _package_name = "([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])"
@@ -76,6 +77,25 @@ def _ensure_valid_resource(value):
             "(e.g. `my_plugin.some_module:my_logo.png`). This resource must be "
             "shipped with the sdist)"
         )
+
+
+def configuration_key(key: str) -> str:
+    """Assert that `key` is usable as a pydantic field / attribute name.
+
+    Configuration and property keys become attribute names on the settings
+    model generated from the manifest (e.g.
+    `get_plugin_settings('plugin').key.subkey`), so they must be valid,
+    non-reserved Python identifiers that do not begin with an underscore
+    (leading underscores are treated as private attributes by pydantic).
+    """
+    if not key.isidentifier() or keyword.iskeyword(key) or key.startswith("_"):
+        raise ValueError(
+            f"{key!r} is not a valid configuration key. Configuration and "
+            "property keys become attribute names on the generated settings "
+            "model, so they must be valid, non-reserved Python identifiers "
+            "that do not begin with an underscore."
+        )
+    return key
 
 
 def validate_icon(value):

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -1,61 +1,10 @@
-import re
-from collections.abc import Iterable
+from typing import Annotated
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AfterValidator, BaseModel, Field, model_validator
+
+from npe2.manifest import _validators
 
 from ._json_schema import ConfigurationJsonSchema
-
-
-def normalize_title(title: str) -> str:
-    """Return a canonical snake_case key for a configuration title.
-
-    Configuration titles are free-form text (e.g. "Demo Configuration for
-    widget 1") but consumers (e.g. napari) use them to derive identifier-like
-    keys / field names.  Normalizing titles to a canonical key lets npe2
-    enforce that titles are unique within a plugin, and lets consumers reuse
-    the same normalization instead of implementing (possibly divergent) ones.
-
-    Examples
-    --------
-    >>> normalize_title('Demo Configuration for widget 1')
-    'demo_configuration_for_widget_1'
-    >>> normalize_title('main widget')
-    'main_widget'
-    """
-    # camelCase -> snake_case (e.g. someSetting -> some_Setting)
-    name = re.sub(r"(?<!^)(?=[A-Z])", "_", title)
-    # any run of non-alphanumeric characters is a separator
-    name = re.sub(r"[^0-9a-zA-Z]+", "_", name)
-    name = re.sub(r"_+", "_", name).strip("_").lower()
-    if not name:
-        name = "settings"
-    if name[0].isdigit():
-        name = f"_{name}"
-    return name
-
-
-def _ensure_unique_normalized(items: Iterable[str], what: str) -> None:
-    """Raise if any two strings in ``items`` normalize to the same key.
-
-    Parameters
-    ----------
-    items : Iterable[str]
-        The free-form strings to check for collisions after
-        :func:`normalize_title`.
-    what : str
-        Human-readable noun phrase used in the error message, e.g.
-        "Configuration titles".
-    """
-    seen: dict[str, str] = {}
-    for original in items:
-        key = normalize_title(original)
-        if key in seen:
-            raise ValueError(
-                f"{what} {seen[key]!r} and {original!r} both normalize to "
-                f"{key!r}; duplicate {what.lower()} are not allowed (case, "
-                "whitespace, and punctuation are ignored)."
-            )
-        seen[key] = original
 
 
 class ConfigurationProperty(ConfigurationJsonSchema):
@@ -102,34 +51,40 @@ class ConfigurationProperty(ConfigurationJsonSchema):
         return values
 
 
+_ConfigurationKey = Annotated[str, AfterValidator(_validators.configuration_key)]
+
+
 class ConfigurationContribution(BaseModel):
     """A configuration contribution for a plugin.
 
     This enables plugins to provide a schema for their configurables.
-    Configuration contributions are used to generate the settings UI.
+    Configuration contributions are used to generate the settings UI. Each
+    configuration contribution is declared under a unique key in
+    `contributions.configuration` (see `ContributionPoints.configuration`);
+    that key, together with each property's key below, is used verbatim to
+    build the path used to access this setting at runtime, e.g.
+    `get_plugin_settings('plugin-name').<configuration-key>.<property-key>`.
     """
 
     title: str = Field(
         ...,
-        description="The heading used for this configuration category. Words like "
-        '"Plugin", "Configuration", and "Settings" are redundant and should not be'
-        "used in your title.",
+        description="The heading used for this configuration category, displayed in "
+        'the settings UI. Words like "Plugin", "Configuration", and "Settings" '
+        "are redundant and should not be used in your title. Unlike the key under "
+        "which this contribution is declared in `contributions.configuration`, the "
+        "title is display text only and does not need to be unique.",
     )
-    properties: dict[str, ConfigurationProperty] = Field(
+    properties: dict[_ConfigurationKey, ConfigurationProperty] = Field(
         ...,
-        description="Configuration properties. In the settings UI, your configuration "
-        "key will be used to namespace and construct a title. Though a plugin can "
-        "contain multiple categories of settings, each plugin setting must still have "
-        "its own unique key. Capital letters in your key are used to indicate word "
-        "breaks. For example, if your key is 'gitMagic.blame.dateFormat', the "
-        "generated title for the setting will look like 'Blame: Date Format'",
+        description="Configuration properties, keyed by a property key that is local "
+        "to this configuration contribution. Each property key must be a valid, "
+        "non-reserved Python identifier that does not begin with an underscore, "
+        "since it is used verbatim as the attribute name for that setting on the "
+        "generated settings model (e.g. "
+        "`get_plugin_settings('plugin-name').<configuration-key>.<property-key>`). "
+        "Property keys only need to be unique within this configuration "
+        "contribution, not across the whole plugin.",
     )
-
-    @model_validator(mode="after")
-    def _validate_unique_property_keys(self):
-        """Property keys must be unique once normalized to snake_case."""
-        _ensure_unique_normalized(self.properties, "Configuration properties")
-        return self
 
     # order: int  # vscode uses this to sort multiple configurations
     # ... I think we can just use the order in which they are declared

--- a/src/npe2/manifest/contributions/_configuration.py
+++ b/src/npe2/manifest/contributions/_configuration.py
@@ -60,7 +60,7 @@ class ConfigurationContribution(BaseModel):
     This enables plugins to provide a schema for their configurables.
     Configuration contributions are used to generate the settings UI. Each
     configuration contribution is declared under a unique key in
-    `contributions.configuration` (see `ContributionPoints.configuration`);
+    `contributions.configurations` (see `ContributionPoints.configurations`);
     that key, together with each property's key below, is used verbatim to
     build the path used to access this setting at runtime, e.g.
     `get_plugin_settings('plugin-name').<configuration-key>.<property-key>`.
@@ -71,7 +71,7 @@ class ConfigurationContribution(BaseModel):
         description="The heading used for this configuration category, displayed in "
         'the settings UI. Words like "Plugin", "Configuration", and "Settings" '
         "are redundant and should not be used in your title. Unlike the key under "
-        "which this contribution is declared in `contributions.configuration`, the "
+        "which this contribution is declared in `contributions.configurations`, the "
         "title is display text only and does not need to be unique.",
     )
     properties: dict[_ConfigurationKey, ConfigurationProperty] = Field(

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -45,7 +45,7 @@ class ContributionPoints(BaseModel):
     submenus: list[SubmenuContribution] | None = None
     keybindings: list[KeyBindingContribution] | None = Field(None, hide_docs=True)
 
-    configuration: dict[_ConfigurationKey, ConfigurationContribution] = Field(
+    configurations: dict[_ConfigurationKey, ConfigurationContribution] = Field(
         default_factory=dict,
         hide_docs=True,
         description="Configuration options for this plugin, keyed by a configuration "

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -54,7 +54,7 @@ class ContributionPoints(BaseModel):
         "editor, headed by that entry's `title`. Each configuration key must be a "
         "valid, non-reserved Python identifier that does not begin with an "
         "underscore, and must be unique within the manifest, since it is used "
-        "verbatim as the attribute name for that settings category on the generated "
+        "verbatim as the attribute name for that setting's category on the generated "
         "settings model (e.g. `get_plugin_settings('plugin-name').<configuration-key>"
         ".<property-key>`).",
     )

--- a/src/npe2/manifest/contributions/_contributions.py
+++ b/src/npe2/manifest/contributions/_contributions.py
@@ -1,10 +1,7 @@
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field
 
 from ._commands import CommandContribution
-from ._configuration import (
-    ConfigurationContribution,
-    _ensure_unique_normalized,
-)
+from ._configuration import ConfigurationContribution, _ConfigurationKey
 from ._keybindings import KeyBindingContribution
 from ._menus import MenuItem
 from ._readers import ReaderContribution
@@ -48,27 +45,16 @@ class ContributionPoints(BaseModel):
     submenus: list[SubmenuContribution] | None = None
     keybindings: list[KeyBindingContribution] | None = Field(None, hide_docs=True)
 
-    configuration: list[ConfigurationContribution] = Field(
-        default_factory=list,
+    configuration: dict[_ConfigurationKey, ConfigurationContribution] = Field(
+        default_factory=dict,
         hide_docs=True,
-        description="Configuration options for this plugin."
-        "This section can either be a single object, representing a single category of"
-        "settings, or an array of objects, representing multiple categories of"
-        "settings. If there are multiple categories of settings, the Settings editor"
-        "will show a submenu in the table of contents for that extension, and the title"
-        "keys will be used for the submenu entry names.",
+        description="Configuration options for this plugin, keyed by a configuration "
+        "key. A plugin can contribute multiple categories of settings by declaring "
+        "multiple entries here; each shows up as its own submenu in the Settings "
+        "editor, headed by that entry's `title`. Each configuration key must be a "
+        "valid, non-reserved Python identifier that does not begin with an "
+        "underscore, and must be unique within the manifest, since it is used "
+        "verbatim as the attribute name for that settings category on the generated "
+        "settings model (e.g. `get_plugin_settings('plugin-name').<configuration-key>"
+        ".<property-key>`).",
     )
-
-    @field_validator("configuration", mode="before")
-    @classmethod
-    def _to_list(cls, v):
-        return v if isinstance(v, list) else [v]
-
-    @model_validator(mode="after")
-    def _validate_unique_configuration_titles(self):
-        """Configuration titles must be unique once normalized to snake_case."""
-        _ensure_unique_normalized(
-            (conf.title for conf in self.configuration),
-            "Configuration titles",
-        )
-        return self

--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -87,7 +87,7 @@ _python_equivalent: dict[str, type] = {
 class ConfigurationJsonSchema(BaseModel):
     """Model for (a subset of) Draft 2020-12 JSON Schema.
 
-    This is the schema model used for the `configuration` contribution.
+    This is the schema model used for the `configurations` contribution.
     https://json-schema.org/understanding-json-schema/reference
     """
 

--- a/src/npe2/manifest/schema.py
+++ b/src/npe2/manifest/schema.py
@@ -35,7 +35,7 @@ __all__ = ("Category",)
 logger = getLogger(__name__)
 
 
-SCHEMA_VERSION = "0.2.1"
+SCHEMA_VERSION = "0.3.0"
 ENTRY_POINT = "napari.manifest"
 NPE1_ENTRY_POINT = "napari.plugin"
 

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -30,7 +30,7 @@ contributions:
     - id: my-plugin.some_function_widget
       title: Create widget from my function
       python_name: my_plugin:make_widget_from_function
-  configuration:
+  configurations:
     reader:
       title: My Plugin
       properties:

--- a/tests/sample/my_plugin/napari.yaml
+++ b/tests/sample/my_plugin/napari.yaml
@@ -31,9 +31,10 @@ contributions:
       title: Create widget from my function
       python_name: my_plugin:make_widget_from_function
   configuration:
-    - title: My Plugin
+    reader:
+      title: My Plugin
       properties:
-        my_plugin.reader.lazy:
+        lazy:
           type: boolean
           default: false
           title: Load lazily

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -6,12 +6,11 @@ from npe2.manifest.contributions import (
     ConfigurationProperty,
     ContributionPoints,
 )
-from npe2.manifest.contributions._configuration import normalize_title
 from npe2.manifest.contributions._json_schema import ValidationError
 
 PROPS = [
     {
-        "plugin.heatmap.location": {
+        "heatmap_location": {
             "title": "Heatmap location",
             "type": "string",
             "default": "right",
@@ -77,65 +76,106 @@ def test_config_validation(schema, valid, invalid):
     assert cfg.has_default is ("default" in schema)
 
 
+def test_configuration_dict_keyed():
+    """`contributions.configuration` is a dict keyed by configuration key."""
+    cp = ContributionPoints(
+        configuration={
+            "reader": {
+                "title": "Reader",
+                "properties": {
+                    "num_layers": {
+                        "title": "Number of layers",
+                        "type": "int",
+                        "default": 3,
+                    },
+                },
+            },
+            "writer": {
+                "title": "Writer",
+                "properties": {
+                    "compression": {
+                        "title": "Compression level",
+                        "type": "str",
+                        "default": "medium",
+                    },
+                },
+            },
+        }
+    )
+    assert set(cp.configuration) == {"reader", "writer"}
+    assert cp.configuration["reader"].properties["num_layers"].default == 3
+
+
 @pytest.mark.parametrize(
-    "title, expected",
+    "key",
     [
-        ("Demo Configuration for widget 1", "demo_configuration_for_widget_1"),
-        ("main widget", "main_widget"),
-        ("someSetting", "some_setting"),
-        # no alphanumeric content at all -> fall back to a generic key
-        ("", "settings"),
-        ("!!!", "settings"),
-        # leading digit -> prefix underscore so the key is a valid identifier
-        ("123 hello", "_123_hello"),
+        "my.reader",  # dots are not valid identifier characters
+        "my-reader",  # dashes are not valid identifier characters
+        "class",  # reserved keyword
+        "1reader",  # can't start with a digit
+        "_reader",  # leading underscore collides with pydantic private attrs
+        "",  # empty string
     ],
 )
-def test_normalize_title(title, expected):
-    assert normalize_title(title) == expected
-
-
-def test_duplicate_configuration_titles_raise():
-    with pytest.raises(PydanticValidationError, match="both normalize to"):
+def test_invalid_configuration_key_raises(key):
+    with pytest.raises(PydanticValidationError, match="not a valid configuration key"):
         ContributionPoints(
-            configuration=[
-                {
-                    "title": "Main Widget",
+            configuration={
+                key: {
+                    "title": "Reader",
                     "properties": {
-                        "p.a": {
-                            "title": "A",
-                            "type": "boolean",
-                            "default": False,
+                        "num_layers": {
+                            "title": "Number of layers",
+                            "type": "int",
+                            "default": 3,
                         },
                     },
                 },
-                {
-                    "title": "main widget",
-                    "properties": {
-                        "p.b": {
-                            "title": "B",
-                            "type": "boolean",
-                            "default": False,
-                        },
-                    },
-                },
-            ]
+            }
         )
 
 
-def test_duplicate_property_keys_raise():
-    with pytest.raises(PydanticValidationError, match="both normalize to"):
+@pytest.mark.parametrize(
+    "key",
+    [
+        "my.lazy",
+        "my-lazy",
+        "class",
+        "1lazy",
+        "_lazy",
+        "",
+    ],
+)
+def test_invalid_property_key_raises(key):
+    with pytest.raises(PydanticValidationError, match="not a valid configuration key"):
         ConfigurationContribution(
             title="My Widget",
             properties={
-                "plugin.a.lazy": {
+                key: {
                     "title": "Lazy",
-                    "type": "boolean",
-                    "default": False,
-                },
-                "plugin.a-lazy": {
-                    "title": "Lazy 2",
                     "type": "boolean",
                     "default": False,
                 },
             },
         )
+
+
+def test_duplicate_configuration_titles_allowed():
+    """Titles are display text only; they no longer need to be unique."""
+    cp = ContributionPoints(
+        configuration={
+            "reader": {
+                "title": "Main Widget",
+                "properties": {
+                    "a": {"title": "A", "type": "boolean", "default": False},
+                },
+            },
+            "writer": {
+                "title": "Main Widget",
+                "properties": {
+                    "b": {"title": "B", "type": "boolean", "default": False},
+                },
+            },
+        }
+    )
+    assert cp.configuration["reader"].title == cp.configuration["writer"].title

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -77,9 +77,9 @@ def test_config_validation(schema, valid, invalid):
 
 
 def test_configuration_dict_keyed():
-    """`contributions.configuration` is a dict keyed by configuration key."""
+    """`contributions.configurations` is a dict keyed by configuration key."""
     cp = ContributionPoints(
-        configuration={
+        configurations={
             "reader": {
                 "title": "Reader",
                 "properties": {
@@ -102,8 +102,8 @@ def test_configuration_dict_keyed():
             },
         }
     )
-    assert set(cp.configuration) == {"reader", "writer"}
-    assert cp.configuration["reader"].properties["num_layers"].default == 3
+    assert set(cp.configurations) == {"reader", "writer"}
+    assert cp.configurations["reader"].properties["num_layers"].default == 3
 
 
 @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ def test_configuration_dict_keyed():
 def test_invalid_configuration_key_raises(key):
     with pytest.raises(PydanticValidationError, match="not a valid configuration key"):
         ContributionPoints(
-            configuration={
+            configurations={
                 key: {
                     "title": "Reader",
                     "properties": {
@@ -163,7 +163,7 @@ def test_invalid_property_key_raises(key):
 def test_duplicate_configuration_titles_allowed():
     """Titles are display text only; they no longer need to be unique."""
     cp = ContributionPoints(
-        configuration={
+        configurations={
             "reader": {
                 "title": "Main Widget",
                 "properties": {
@@ -178,4 +178,4 @@ def test_duplicate_configuration_titles_allowed():
             },
         }
     )
-    assert cp.configuration["reader"].title == cp.configuration["writer"].title
+    assert cp.configurations["reader"].title == cp.configurations["writer"].title

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -251,3 +251,25 @@ def test_writer_invalid_layer_type_expressions(expr, uses_sample_plugin):
 def test_invalid_command_id(id):
     with pytest.raises(ValueError):
         _validators.command_id(id)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "my.reader",  # dots are not valid identifier characters
+        "my-reader",  # dashes are not valid identifier characters
+        "has space",
+        "class",  # reserved keyword
+        "1reader",  # can't start with a digit
+        "_reader",  # leading underscore collides with pydantic private attrs
+        "",  # empty string
+    ],
+)
+def test_invalid_configuration_key(key):
+    with pytest.raises(ValueError, match="not a valid configuration key"):
+        _validators.configuration_key(key)
+
+
+@pytest.mark.parametrize("key", ["reader", "num_layers", "gpuAcceleration", "a1"])
+def test_valid_configuration_key(key):
+    assert _validators.configuration_key(key) == key


### PR DESCRIPTION
As discussed in triage meeting today, and addressing concerns raised in [this zulip chat]([#2026-naPLari-Krakow-public > Plugin Settings (ConfigurationContribution) @ 💬](https://napari.zulipchat.com/#narrow/channel/619705-2026-naPLari-Krakow-public/topic/Plugin.20Settings.20.28ConfigurationContribution.29/near/615071514)), this PR updates the manifest `configuration` field to be a dictionary, with each `ConfigurationContribution` being given a unique key within the manifest.

This allows us to use the key on the napari side to construct the key used with `get_plugin_settings()`.

Prior to this PR, the title of each `ConfigurationContribution` would be "keyified" on the napari side, and concatenated with a stripped version of the `ConfigurationProperty` key for programmatic access. This made it more difficult for plugin developers to reason about how to programmatically access each property, and made it harder to define the necessary "uniqueness" of each field.

Now, each `ConfigurationContribution` key must be unique within a manifest, and each `ConfigurationProperty` key must be unique within its `ConfigurationContribution`. Both keys are explicitly declared in the manifest, and titles are used only for display.

Note this means we undo the validation added in #501, because the only validation needed is that the keys are valid Python identifiers, and unique*.

The only other changes in this PR are:

- rename manifest.configuration to manifest.configurations to match all our other fields and indicate it can hold multiple
- bump the schema version (since technically any previously written manifests would now be invalid)

* See #504 for caveat on this