### PR TITLE
Disallow duplicate keys in the same yaml/json mapping

### DIFF
--- a/src/npe2/manifest/_bases.py
+++ b/src/npe2/manifest/_bases.py
@@ -7,6 +7,53 @@ import yaml
 from pydantic import BaseModel, PrivateAttr
 
 
+class _UniqueKeyYamlLoader(yaml.SafeLoader):
+    """YAML loader that raises on duplicate keys within a single mapping.
+
+    PyYAML (like the stdlib `json` module) silently keeps the *last* value
+    for a duplicate key within a mapping, which would let e.g. two
+    `contributions.configurations` entries share a key and silently
+    discard one during parsing -- before pydantic ever sees the data to
+    validate it. This loader catches that at parse time instead.
+    """
+
+    def construct_mapping(self, node, deep=False):
+        seen = set()
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            seen.add(key)
+        return super().construct_mapping(node, deep=deep)
+
+
+def _load_yaml_no_duplicates(stream):
+    return yaml.load(stream, Loader=_UniqueKeyYamlLoader)
+
+
+def _no_duplicate_keys_object_pairs_hook(pairs):
+    """`object_pairs_hook` for `json.load` that rejects duplicate object keys.
+
+    See `_UniqueKeyYamlLoader` for why: the stdlib `json` module otherwise
+    silently keeps the last value for a duplicate key.
+    """
+    seen: dict = {}
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"Duplicate key {key!r} found while parsing JSON.")
+        seen[key] = value
+    return seen
+
+
+def _load_json_no_duplicates(stream):
+    return json.load(stream, object_pairs_hook=_no_duplicate_keys_object_pairs_hook)
+
+
 class ImportExportModel(BaseModel):
     """Model mixin/base class that provides read/write from toml/yaml/json.
 
@@ -73,7 +120,7 @@ class ImportExportModel(BaseModel):
 
         loader: Callable
         if path.suffix.lower() == ".json":
-            loader = json.load
+            loader = _load_json_no_duplicates
         elif path.suffix.lower() == ".toml":
             try:
                 import tomllib
@@ -82,7 +129,7 @@ class ImportExportModel(BaseModel):
 
             loader = tomllib.load
         elif path.suffix.lower() in (".yaml", ".yml"):
-            loader = yaml.safe_load
+            loader = _load_yaml_no_duplicates
         else:
             raise ValueError(f"unrecognized file extension: {path}")  # pragma: no cover
 

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -1,0 +1,110 @@
+import json
+
+import pytest
+import yaml
+
+from npe2 import PluginManifest
+
+MINIMAL_MANIFEST = {
+    "name": "my-plugin",
+    "contributions": {
+        "commands": [
+            {
+                "id": "my-plugin.hello",
+                "title": "Hello",
+                "python_name": "my_plugin:hello",
+            },
+        ],
+        "menus": {
+            "napari/layers/context": [
+                {"command": "my-plugin.hello"},
+            ],
+        },
+    },
+}
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text)
+    return path
+
+
+def test_yaml_duplicate_top_level_menu_key_raises(tmp_path):
+    text = """
+name: my-plugin
+contributions:
+  commands:
+    - id: my-plugin.hello
+      title: Hello
+      python_name: my_plugin:hello
+  menus:
+    napari/layers/context:
+      - command: my-plugin.hello
+    napari/layers/context:
+      - command: my-plugin.hello
+"""
+    path = _write(tmp_path, "napari.yaml", text)
+    with pytest.raises(yaml.constructor.ConstructorError, match="duplicate key"):
+        PluginManifest.from_file(path)
+
+
+def test_json_duplicate_top_level_menu_key_raises(tmp_path):
+    # can't use json.dumps for this -- it would collapse the duplicate key
+    # before we ever get to write the file.
+    text = """
+{
+  "name": "my-plugin",
+  "contributions": {
+    "commands": [
+      {"id": "my-plugin.hello", "title": "Hello", "python_name": "my_plugin:hello"}
+    ],
+    "menus": {
+      "napari/layers/context": [{"command": "my-plugin.hello"}],
+      "napari/layers/context": [{"command": "my-plugin.hello"}]
+    }
+  }
+}
+"""
+    path = _write(tmp_path, "napari.json", text)
+    with pytest.raises(ValueError, match="Duplicate key 'napari/layers/context'"):
+        PluginManifest.from_file(path)
+
+
+def test_yaml_repeated_sibling_key_names_are_fine(tmp_path):
+    """The same key name in unrelated, sibling mappings is not a collision."""
+    text = yaml.safe_dump(MINIMAL_MANIFEST)
+    path = _write(tmp_path, "napari.yaml", text)
+    mf = PluginManifest.from_file(path)
+    assert mf.contributions.menus["napari/layers/context"][0].command == (
+        "my-plugin.hello"
+    )
+
+
+def test_json_repeated_sibling_key_names_are_fine(tmp_path):
+    text = json.dumps(MINIMAL_MANIFEST)
+    path = _write(tmp_path, "napari.json", text)
+    mf = PluginManifest.from_file(path)
+    assert mf.contributions.menus["napari/layers/context"][0].command == (
+        "my-plugin.hello"
+    )
+
+
+def test_toml_duplicate_table_raises(tmp_path):
+    """tomllib already rejects duplicate keys per the TOML spec; nothing npe2-specific
+    is needed here, but we assert on it so a regression would be caught."""
+    text = """
+name = "my-plugin"
+
+[[contributions.commands]]
+id = "my-plugin.hello"
+title = "Hello"
+python_name = "my_plugin:hello"
+
+[contributions.menus]
+"napari/layers/context" = [{command = "my-plugin.hello"}]
+"napari/layers/context" = [{command = "my-plugin.hello"}]
+"""
+    path = _write(tmp_path, "napari.toml", text)
+    with pytest.raises(Exception, match=r"twice|Cannot overwrite"):
+        PluginManifest.from_file(path)


### PR DESCRIPTION
Closes #504 

This PR adds a yaml and json parser that ensure duplicate keys are not declared in the same mapping e.g. in the `menus` contribution dict, the `configurations` contribution dict (being added in #503), or within a single `ConfigurationContribution` when keying individual properties.

TOML already disallows this, but added a regression test for the sake of completeness.

This PR was heavily Claude assisted, but I've reviewed it and it seems to make sense to me!