### PR TITLE
Validate Enum values for ConfigurationJsonSchema

### DIFF
--- a/src/npe2/manifest/contributions/_json_schema.py
+++ b/src/npe2/manifest/contributions/_json_schema.py
@@ -84,6 +84,21 @@ _python_equivalent: dict[str, type] = {
 }
 
 
+def _enum_member_type_ok(member: Any, json_type: str) -> bool:
+    """Return True if ``member`` is an acceptable value for ``json_type``."""
+    # ``bool`` is a subclass of ``int`` in Python, so exclude booleans from
+    # the numeric types explicitly.
+    if json_type == "boolean":
+        return isinstance(member, bool)
+    if json_type == "integer":
+        return isinstance(member, int) and not isinstance(member, bool)
+    if json_type == "number":
+        return isinstance(member, (int, float)) and not isinstance(member, bool)
+    if json_type == "string":
+        return isinstance(member, str)
+    return False
+
+
 class ConfigurationJsonSchema(BaseModel):
     """Model for (a subset of) Draft 2020-12 JSON Schema.
 
@@ -185,6 +200,30 @@ class ConfigurationJsonSchema(BaseModel):
             values.pop("enum")
 
         return values
+
+    @model_validator(mode="after")
+    def _validate_enum(self) -> ConfigurationJsonSchema:
+        """Validate `enum` members and `default` against the declared `type`.
+
+        `enum` members must be of the same type as the property's `type`, and
+        the (required) `default` must be one of the enum values. Without these
+        checks a bad manifest only fails much later, when napari tries to build
+        the settings model.
+        """
+        if self.enum is None:
+            return self
+        bad_members = [m for m in self.enum if not _enum_member_type_ok(m, self.type)]
+        if bad_members:
+            raise ValueError(
+                f"enum members {bad_members!r} do not match the property type "
+                f"{self.type!r}; enum members must be of the same type as "
+                "`type`"
+            )
+        if self.default not in self.enum:
+            raise ValueError(
+                f"default {self.default!r} is not one of the enum values {self.enum!r}"
+            )
+        return self
 
     @property
     def has_constraint(self) -> bool:

--- a/tests/test_config_contribution.py
+++ b/tests/test_config_contribution.py
@@ -78,6 +78,37 @@ def test_config_validation(schema, valid, invalid):
     assert cfg.has_default is ("default" in schema)
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {
+            "title": "T",
+            "type": "string",
+            "default": "blue",
+            "enum": ["red", "green"],
+        },
+        {"title": "T", "type": "integer", "default": 3, "enum": [1, 2]},
+    ],
+)
+def test_default_must_be_in_enum(schema):
+    with pytest.raises(PydanticValidationError, match="not one of the enum values"):
+        ConfigurationProperty(**schema)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"title": "T", "type": "integer", "default": 1, "enum": [1, "two"]},
+        {"title": "T", "type": "boolean", "default": True, "enum": [True, 1]},
+        {"title": "T", "type": "string", "default": "a", "enum": ["a", 2]},
+        {"title": "T", "type": "number", "default": 1.5, "enum": [1.5, "x"]},
+    ],
+)
+def test_enum_members_must_match_type(schema):
+    with pytest.raises(PydanticValidationError, match="do not match the property type"):
+        ConfigurationProperty(**schema)
+
+
 def test_configuration_dict_keyed():
     """`contributions.configurations` is a dict keyed by configuration key."""
     cp = ContributionPoints(


### PR DESCRIPTION
# Description

In napari/napari#9308, I discovered that enum values could be anything arbitrary, and fixed it. This upstreams Enum member validation to npe2, so that, at least, plugin authors don't hit it prior to testing in napari. It maps Enum member types to JSON schema types, and checks that the Enum members are of the correct type for the JSON schema type. It also makes sure that the default value is an Enum member.